### PR TITLE
[COOK-1182] remove the quotes from the first parameter of the start command. 

### DIFF
--- a/providers/package.rb
+++ b/providers/package.rb
@@ -154,7 +154,7 @@ def uninstall_command_template
   when :msi
     "msiexec %2$s %1$s"
   else
-    "start /wait /d\"%1$s\" %2$s %3$s"
+    "start /wait /d%1$s %2$s %3$s"
   end
 end
 


### PR DESCRIPTION
Start does not treat them as a nice way to create a single token for a path with spaces, instead it interperets quotes as a signal to set the window title. See http://msdn.microsoft.com/en-us/library/bb491005.aspx
