### PR TITLE
[COOK-2126] Add checksum (SHA256) support for windows_zipfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ Most version of Windows do not ship with native cli utility for managing compres
 - path: name attribute. The path where files will be unzipped to.
 - source: The source of the zip file. This can either be a URI or a local path.
 - overwrite: force an overwrite of the files if the already exists.
+- checksum: useful if source is remote, the SHA-256 checksum of the file--if the local file matches the checksum, Chef will not download it
 
 ### Examples
 

--- a/providers/zipfile.rb
+++ b/providers/zipfile.rb
@@ -28,7 +28,7 @@ action :unzip do
   ensure_rubyzip_gem_installed
   Chef::Log.debug("unzip #{@new_resource.source} => #{@new_resource.path} (overwrite=#{@new_resource.overwrite})")
 
-  Zip::ZipFile.open(cached_file(@new_resource.source)) do |zip|
+  Zip::ZipFile.open(cached_file(@new_resource.source, @new_resource.checksum)) do |zip|
     zip.each do |entry|
       path = ::File.join(@new_resource.path, entry.name)
       FileUtils.mkdir_p(::File.dirname(path))

--- a/resources/zipfile.rb
+++ b/resources/zipfile.rb
@@ -25,6 +25,7 @@ actions :unzip, :zip
 attribute :path, :kind_of => String, :name_attribute => true
 attribute :source, :kind_of => String
 attribute :overwrite, :kind_of => [ TrueClass, FalseClass ], :default => false
+attribute :checksum, :kind_of => String
 
 def initialize(name, run_context=nil)
   super


### PR DESCRIPTION
This adds a "checksum" attribute for windows_zipfile. See JIRA ticket [COOK-2126](http://tickets.opscode.com/browse/COOK-2126).
