### PR TITLE
Cook-2149: Add debug message to print installer command line args

### DIFF
--- a/providers/package.rb
+++ b/providers/package.rb
@@ -120,6 +120,7 @@ def install_package(name,version)
   Chef::Log.debug("Processing #{@new_resource} as a #{installer_type} installer.")
   install_args = [cached_file(@new_resource.source, @new_resource.checksum), expand_options(unattended_installation_flags), expand_options(@new_resource.options)]
   Chef::Log.info("Starting installation...this could take awhile.")
+  Chef::Log.debug "Install command: #{ sprintf(install_command_template, *install_args) }"
   shell_out!(sprintf(install_command_template, *install_args), {:timeout => @new_resource.timeout, :returns => [0,42,127]})
 end
 


### PR DESCRIPTION
Cook-2149: Add debug message to print installer command line args

http://tickets.opscode.com/browse/COOK-2149
