### PR TITLE
[COOK-968] windows_package: Put source path in quotes for install

### DIFF
--- a/providers/package.rb
+++ b/providers/package.rb
@@ -146,7 +146,7 @@ def install_command_template
   when :msi
     "msiexec%2$s \"%1$s\"%3$s"
   else
-    "start \"\" /wait %1$s%2$s%3$s"
+    "start \"\" /wait \"%1$s\"%2$s%3$s"
   end
 end
 


### PR DESCRIPTION
This is a one-line patch to allow spaces in the `source` path in `windows_package`.

See JIRA ticket [COOK-968](http://tickets.opscode.com/browse/COOK-968).
