### PR TITLE
[COOK-2729] - allow only http, https URI schemes

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -65,7 +65,7 @@ module Windows
     def cached_file(source, checksum=nil, windows_path=true)
       @installer_file_path ||= begin
 
-        if %w[http https].include?(URI.parse(source).scheme)
+        if source =~ ::URI::ABS_URI && %w[http https].include?(URI.parse(source).scheme)
           uri = ::URI.parse(::URI.unescape(source))
           cache_file_path = "#{Chef::Config[:file_cache_path]}/#{::File.basename(uri.path)}"
           Chef::Log.debug("Caching a copy of file #{source} at #{cache_file_path}")


### PR DESCRIPTION
When using Windows qualified filepaths (C:/foo), the #absolute? method
for URI returns true, because "C" is the scheme.

This change checks that the URI is http or https scheme, so it can be
passed off to remote_file appropriately.
