### PR TITLE
Added windows_feature support for 2 new DISM attributes: all, source

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ For more information on Roles, Role Services and Features see the [Microsoft Tec
 ### Attribute Parameters
 
 - feature_name: name of the feature/role to install.  The same feature may have different names depending on the provider used (ie DHCPServer vs DHCP; DNS-Server-Full-Role vs DNS).
+- all: Boolean. Optional. Default: false. DISM provider only. Forces all dependencies to be installed.
+- source: String. Optional. DISM provider only. Uses local repository for feature install.
 
 ### Providers
 
@@ -147,6 +149,13 @@ For more information on Roles, Role Services and Features see the [Microsoft Tec
       windows_feature feature do
         action :remove
       end
+    end
+
+    # enable .Net 3.5.1 on Server 2012 using repository files on DVD
+    windows_feature "NetFx3" do
+      action :install
+      all true
+      source "d:\sources\sxs"
     end
 
 windows\_package

--- a/providers/feature_dism.rb
+++ b/providers/feature_dism.rb
@@ -23,13 +23,13 @@ include Chef::Mixin::ShellOut
 include Windows::Helper
 
 def install_feature(name)
-  # return code 3010 is valid, it indicates a reboot is required
-  shell_out!("#{dism} /online /enable-feature /featurename:#{@new_resource.feature_name} /norestart", {:returns => [0,42,127,3010]})
+	addSource = @new_resource.source ? " /LimitAccess /Source:\"#{@new_resource.source}\" " : ""
+	addAll = @new_resource.all ? " /All " : ""
+  shell_out!("#{dism} /online /enable-feature /featurename:#{@new_resource.feature_name} /norestart#{addSource}#{addAll}", {:returns => [0,42,127]})
 end
 
 def remove_feature(name)
-  # return code 3010 is valid, it indicates a reboot is required
-  shell_out!("#{dism} /online /disable-feature /featurename:#{@new_resource.feature_name} /norestart", {:returns => [0,42,127,3010]})
+  shell_out!("#{dism} /online /disable-feature /featurename:#{@new_resource.feature_name} /norestart", {:returns => [0,42,127]})
 end
 
 def installed?

--- a/resources/feature.rb
+++ b/resources/feature.rb
@@ -23,6 +23,8 @@ include Windows::Helper
 actions :install, :remove
 
 attribute :feature_name, :kind_of => String, :name_attribute => true
+attribute :source, :kind_of => String
+attribute :all, :kind_of => [ TrueClass, FalseClass ], :default => false
 
 def initialize(name, run_context=nil)
   super


### PR DESCRIPTION
Added a couple switches for the default DISM provider:
- 'all' will add the /all switch
- 'source' will add /LimitAccess /Source:"[source_string_provided]"

All is useful when components have dependencies and source is useful for loading on-demand stuff that you can pull locally if need be (like the NetFx3 package).
Also updated the README (including an example)
