### PR TITLE
[COOK-3126]: Adding ability to have tasks scheduled on start.  Note, the...

### DIFF
--- a/providers/task.rb
+++ b/providers/task.rb
@@ -26,7 +26,8 @@ action :create do
     Chef::Log.info "#{@new_resource} task already exists - nothing to do"
   else
     cmd =  "schtasks /Create /TN \"#{@new_resource.name}\" "
-    cmd += "/SC #{@new_resource.frequency} /MO #{@new_resource.frequency_modifier} "
+    cmd += "/SC #{@new_resource.frequency} "
+    cmd += "/MO #{@new_resource.frequency_modifier} " if [:minute, :hourly, :daily, :weekly, :monthly].include?(@new_resource.frequency)
     cmd += "/TR \"#{@new_resource.command}\" "
     if @new_resource.user && @new_resource.password
       cmd += "/RU \"#{@new_resource.user}\" /RP \"#{@new_resource.password}\" "

--- a/resources/task.rb
+++ b/resources/task.rb
@@ -36,6 +36,7 @@ attribute :frequency, :equal_to => [:minute,
                                     :monthly,
                                     :once,
                                     :on_logon,
+                                    :onstart,
                                     :on_idle], :default => :hourly
 
 attr_accessor :exists, :status


### PR DESCRIPTION
... modifier is onstart and not on_start.  I suspect that on_logon and on_idle are currently broken the way this is written.
