### PR TITLE
[COOK-3458] Add start_date and start_time in windows_task

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,8 @@ Server 2008 due to API usage.
 - run_level: Run with limited or highest privileges.
 - frequency: Frequency with which to run the task. (hourly, daily, ect.)
 - frequency_modifier: Multiple for frequency. (15 minutes, 2 days)
+- start_day: Specifies the first date on which the task runs. Optional string (MM/DD/YYYY)
+- start_time: Specifies the start time to run the task. Optional string (HH:mm)
 
 ### Examples
 

--- a/providers/task.rb
+++ b/providers/task.rb
@@ -29,6 +29,8 @@ action :create do
     cmd =  "schtasks /Create #{use_force} /TN \"#{@new_resource.name}\" "
     cmd += "/SC #{@new_resource.frequency} "
     cmd += "/MO #{@new_resource.frequency_modifier} " if [:minute, :hourly, :daily, :weekly, :monthly].include?(@new_resource.frequency)
+    cmd += "/SD \"#{@new_resource.start_day}\" " unless @new_resource.start_day.nil?
+    cmd += "/ST \"#{@new_resource.start_time}\" " unless @new_resource.start_time.nil?
     cmd += "/TR \"#{@new_resource.command}\" "
     if @new_resource.user && @new_resource.password
       cmd += "/RU \"#{@new_resource.user}\" /RP \"#{@new_resource.password}\" "

--- a/resources/task.rb
+++ b/resources/task.rb
@@ -39,6 +39,8 @@ attribute :frequency, :equal_to => [:minute,
                                     :on_logon,
                                     :onstart,
                                     :on_idle], :default => :hourly
+attribute :start_day, :kind_of => String, :default => nil
+attribute :start_time, :kind_of => String, :default => nil
 
 attr_accessor :exists, :status
 


### PR DESCRIPTION
Ability to set /SD (start_date) and /ST (start_time) options in schtasks.
