### PR TITLE
[COOK-3715] Unable to create a startup task with no login

### DIFF
--- a/providers/task.rb
+++ b/providers/task.rb
@@ -25,7 +25,7 @@ action :create do
   if @current_resource.exists
     Chef::Log.info "#{@new_resource} task already exists - nothing to do"
   else
-    if @new_resource.user and @new_resource.password.nil? Chef::Log.debug "#{@new_resource} did not specify a password, creating task without a password"
+    if @new_resource.user and @new_resource.password.nil? then Chef::Log.debug "#{@new_resource} did not specify a password, creating task without a password" end
     use_force = @new_resource.force ? '/F' : ''
     cmd =  "schtasks /Create #{use_force} /TN \"#{@new_resource.name}\" "
     schedule  = @new_resource.frequency == :on_logon ? "ONLOGON" : @new_resource.frequency


### PR DESCRIPTION
This allows for setting a task user to 'system' without password and have it run on startup without having to log in:

https://tickets.opscode.com/browse/COOK-3715
