### PR TITLE
[COOK-3988] Don't unescape URI before constructing it.

### DIFF
--- a/libraries/windows_helper.rb
+++ b/libraries/windows_helper.rb
@@ -65,9 +65,9 @@ module Windows
     def cached_file(source, checksum=nil, windows_path=true)
       @installer_file_path ||= begin
 
-        if source =~ ::URI::ABS_URI && %w[http https].include?(URI.parse(source).scheme)
-          uri = ::URI.parse(::URI.unescape(source))
-          cache_file_path = "#{Chef::Config[:file_cache_path]}/#{::File.basename(uri.path)}"
+        if source =~ ::URI::ABS_URI && %w[ftp http https].include?(URI.parse(source).scheme)
+          uri = ::URI.parse(source)
+          cache_file_path = "#{Chef::Config[:file_cache_path]}/#{::File.basename(::URI.unescape(uri.path))}"
           Chef::Log.debug("Caching a copy of file #{source} at #{cache_file_path}")
           r = Chef::Resource::RemoteFile.new(cache_file_path, run_context)
           r.source(source)


### PR DESCRIPTION
However, unescape it while constructing the file cache's filename.

Also, remote_file resource now understands FTP URLs, so support that as well.
