### PR TITLE
Do not specifically depend on powershell

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,4 +7,4 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.12.4'
 supports         'windows'
 depends          'chef_handler'
-depends          'powershell'
+


### PR DESCRIPTION
As written in the documentation: "We cannot specifically depend on Opscode's powershell, because powershell depends on this cookbook".
It creates a cyclical dependency.
