### PR TITLE
Remove circular dependency on powershell

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,4 +7,3 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.12.4'
 supports         'windows'
 depends          'chef_handler'
-depends          'powershell'


### PR DESCRIPTION
The dependency on powershell makes a circular dependency as powershell is already dependent on windows. 

This breaks librarian-chef runs.
