### PR TITLE
COOK-4620 Ensure win_friendly_path doesn't error out when ALT_SEPARATOR is nil

### DIFF
--- a/libraries/windows_helper.rb
+++ b/libraries/windows_helper.rb
@@ -28,7 +28,7 @@ module Windows
     # returns windows friendly version of the provided path,
     # ensures backslashes are used everywhere
     def win_friendly_path(path)
-      path.gsub(::File::SEPARATOR, ::File::ALT_SEPARATOR) if path
+      path.gsub(::File::SEPARATOR, ::File::ALT_SEPARATOR || '\\') if path
     end
 
     # account for Window's wacky File System Redirector


### PR DESCRIPTION
This can happen when using the win_friendly_path method on a Linux box, for example when writing ChefSpec tests on an OS X dev box.

https://github.com/sethvargo/chefspec/issues/371
