### PR TITLE
[COOK-4728] Allow reboot handler as exception handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The following cookbooks provided by Opscode are required as noted:
 Attributes
 ----------
 * `node['windows']['allow_pending_reboots']` - used to configure the `WindowsRebootHandler` (via the `windows::reboot_handler` recipe) to act on pending reboots. default is true (ie act on pending reboots).  The value of this attribute only has an effect if the `windows::reboot_handler` is in a node's run list.
+* `node['windows']['allow_reboot_on_failure']` - used to register the `WindowsRebootHandler` (via the `windows::reboot_handler` recipe) as an exception handler too to act on reboots not only at the end of successful Chef runs, but even at the end of failed runs. default is false (ie reboot only after successful runs).  The value of this attribute only has an effect if the `windows::reboot_handler` is in a node's run list.
 
 
 Resource/Provider
@@ -562,7 +563,7 @@ end
 Exception/Report Handlers
 -------------------------
 ### WindowsRebootHandler
-Required reboots are a necessary evil of configuring and managing Windows nodes.  This report handler (ie fires at the end of successful Chef runs) acts on requested (Chef initiated) or pending (as determined by the OS per configuration action we performed) reboots.  The `allow_pending_reboots` initialization argument should be set to false if you do not want the handler to automatically reboot a node if it has been determined a reboot is pending.  Reboots can still be requested explicitly via the `windows_reboot` LWRP.
+Required reboots are a necessary evil of configuring and managing Windows nodes.  This report handler (ie fires at the end of Chef runs) acts on requested (Chef initiated) or pending (as determined by the OS per configuration action we performed) reboots.  The `allow_pending_reboots` initialization argument should be set to false if you do not want the handler to automatically reboot a node if it has been determined a reboot is pending.  Reboots can still be requested explicitly via the `windows_reboot` LWRP.
 
 ### Initialization Arguments
 - `allow_pending_reboots`: indicator on whether the handler should act on a the Window's 'pending reboot' state. default is true
@@ -636,6 +637,8 @@ override_attributes(
 ```
 
 This will still allow a reboot to be explicitly requested via the `windows_reboot` LWRP.
+
+By default, the handler will only be registered as a report handler, meaning that it will only fire at the end of successful Chef runs. If the run fails, pending or requested reboots will be ignored. This can lead to a situation where some package was installed and notified a reboot request via the `windows_reboot` LWRP, and then the run fails for some unrelated reason, and the reboot request gets dropped because the resource that notified the reboot request will already be up-to-date at the next run and will not request a reboot again, and thus the requested reboot will never be performed. To change this behavior and register the handler as an exception handler that fires at the end of failed runs too, override `node['windows']['allow_reboot_on_failure']` and set the value to true.
 
 
 License & Authors

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,5 +19,6 @@
 #
 
 default['windows']['allow_pending_reboots'] = true
+default['windows']['allow_reboot_on_failure'] = false
 default['windows']['rubyzipversion'] = nil
 default['windows']['reboot_timeout'] = 60

--- a/recipes/reboot_handler.rb
+++ b/recipes/reboot_handler.rb
@@ -27,6 +27,6 @@ end
 chef_handler 'WindowsRebootHandler' do
   source "#{node['chef_handler']['handler_path']}/windows_reboot_handler.rb"
   arguments node['windows']['allow_pending_reboots']
-  supports :report => true, :exception => false
+  supports :report => true, :exception => node['windows']['allow_reboot_on_failure']
   action :enable
 end


### PR DESCRIPTION
Add the allow_reboot_on_failure attribute to register the
WindowsRebootHandler as an exception handler too, to allow performing
reboots even if the Chef run fails. This is nice to have and reduces the
risk of dropping reboot requests.
