### PR TITLE
[COOK-4739] - Adding use_inline_resources to providers that use Chef resources

### DIFF
--- a/providers/auto_run.rb
+++ b/providers/auto_run.rb
@@ -17,6 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+use_inline_resources if defined?(use_inline_resources)
 
 action :create do
   windows_registry 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run' do

--- a/providers/batch.rb
+++ b/providers/batch.rb
@@ -17,6 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+use_inline_resources if defined?(use_inline_resources)
 
 require 'tempfile'
 require 'chef/resource/execute'

--- a/providers/path.rb
+++ b/providers/path.rb
@@ -17,6 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+use_inline_resources if defined?(use_inline_resources)
 
 action :add do
   env "PATH" do

--- a/providers/printer.rb
+++ b/providers/printer.rb
@@ -17,6 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+use_inline_resources if defined?(use_inline_resources)
 
 # Support whyrun
 def whyrun_supported?

--- a/providers/printer_port.rb
+++ b/providers/printer_port.rb
@@ -17,6 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+use_inline_resources if defined?(use_inline_resources)
 
 # Support whyrun
 def whyrun_supported?


### PR DESCRIPTION
This adds use_inline_resources to a few of the resources to support external notifications. I've also added a checking for use_inline_resources support to prevent Chef 10 users from blowing up.
