### PR TITLE
require Chef::Mixin::PowershellOut before using it

### DIFF
--- a/libraries/windows_architecture_helper.rb
+++ b/libraries/windows_architecture_helper.rb
@@ -82,5 +82,6 @@ end
 # Required for clients that don't have Chef::Mixin::WindowsArchitectureHelper in
 # core chef.
 if ::Chef::Platform.windows?
+  require_relative 'powershell_out'
   Chef::Mixin::PowershellOut.send(:include, Chef::Mixin::WindowsArchitectureHelper)
 end


### PR DESCRIPTION
When this cookbook compiles on nodes using chef 10, the following error shows up:

```
NameError: uninitialized constant Chef::Mixin::PowershellOut
C:/chef/cache/cookbooks/windows/libraries/windows_architecture_helper.rb:85:in `<top (required)>'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/lib/chef/run_context.rb:140:in `load'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/lib/chef/run_context.rb:140:in `block in load_libraries'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/lib/chef/run_context.rb:230:in `call'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/lib/chef/run_context.rb:230:in `block (2 levels) in foreach_cookbook_load_segment'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/lib/chef/run_context.rb:229:in `each'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/lib/chef/run_context.rb:229:in `block in foreach_cookbook_load_segment'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/lib/chef/run_context.rb:227:in `each'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/lib/chef/run_context.rb:227:in `foreach_cookbook_load_segment'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/lib/chef/run_context.rb:137:in `load_libraries'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/lib/chef/run_context.rb:62:in `load'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/lib/chef/client.rb:198:in `setup_run_context'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/lib/chef/client.rb:418:in `do_run'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/lib/chef/client.rb:176:in `run'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/lib/chef/application.rb:135:in `run_chef_client'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/lib/chef/application/client.rb:283:in `block in run_application'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/lib/chef/application/client.rb:274:in `loop'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/lib/chef/application/client.rb:274:in `run_application'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/lib/chef/application.rb:65:in `run'
C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.28.2-x86-mingw32/bin/chef-client:26:in `<top (required)>'
C:/opscode/chef/bin/chef-client:23:in `load'
C:/opscode/chef/bin/chef-client:23:in `<main>'
```

This seems to be somewhat related to [COOK-3330](https://tickets.opscode.com/browse/COOK-3330). This isn't a problem on Chef 11 and I know Chef 10 is ancient and we shouldn't be using it, but it'd be nice if this worked on 10.

Also it seemed okay to use `require_relative` because other library classes do this as well: https://github.com/opscode-cookbooks/windows/blob/v1.34.2/libraries/version.rb#L22
