### PR TITLE
Fix deprecations on ChefSpec >= 4.1

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,16 +1,26 @@
 if defined?(ChefSpec)
-  ChefSpec::Runner.define_runner_method :windows_package
-  ChefSpec::Runner.define_runner_method :windows_feature
-  ChefSpec::Runner.define_runner_method :windows_task
-  ChefSpec::Runner.define_runner_method :windows_path
-  ChefSpec::Runner.define_runner_method :windows_batch
-  ChefSpec::Runner.define_runner_method :windows_pagefile
-  ChefSpec::Runner.define_runner_method :windows_zipfile
-  ChefSpec::Runner.define_runner_method :windows_shortcut
-  ChefSpec::Runner.define_runner_method :windows_auto_run
-  ChefSpec::Runner.define_runner_method :windows_printer
-  ChefSpec::Runner.define_runner_method :windows_printer_port
-  ChefSpec::Runner.define_runner_method :windows_reboot
+  matchers = [
+    :windows_package,
+    :windows_feature,
+    :windows_task,
+    :windows_path,
+    :windows_batch,
+    :windows_pagefile,
+    :windows_zipfile,
+    :windows_shortcut,
+    :windows_auto_run,
+    :windows_printer,
+    :windows_printer_port,
+    :windows_reboot
+  ]
+
+  matchers.each do |matcher|
+    if ChefSpec::VERSION >= '4.1.0'
+      ChefSpec.define_matcher matcher
+    else
+      ChefSpec::Runner.define_runner_method matcher
+    end
+  end
 
   #
   # Assert that a +windows_package+ resource exists in the Chef run with the


### PR DESCRIPTION
I was getting a ton of warnings when running chefspec.

> [DEPRECATION] `ChefSpec::Runner.define_runner_method' is deprecated. Please use`ChefSpec.define_matcher' instead. (called from spec/support/factories.rb:29:in `block in setup_node')
> "/var/folders/30/vtzm8b791v35g4v99c52jgx80000gn/T/d20141024-86388-ddr9vz/cookbooks/windows/libraries/matchers.rb:2:in`<top (required)>'"

I've tested locally, this gets rid of the warnings and also gets rid of some duplication.
