### PR TITLE
Dup input to ExpandEnvironmentStrings to make ruby 2.0 happy

### DIFF
--- a/libraries/windows_helper.rb
+++ b/libraries/windows_helper.rb
@@ -90,7 +90,7 @@ module Windows
       # We pick 32k because that is the largest it could be:
       # http://msdn.microsoft.com/en-us/library/windows/desktop/ms724265%28v=vs.85%29.aspx
       buf = 0.chr * 32 * 1024 # 32k
-      if ExpandEnvironmentStrings.call(path, buf, buf.length) == 0
+      if ExpandEnvironmentStrings.call(path.dup, buf, buf.length) == 0
         raise Chef::Exceptions::Win32APIError, "Failed calling ExpandEnvironmentStrings (received 0)"
       end
       buf.strip


### PR DESCRIPTION
Should solve https://github.com/opscode-cookbooks/windows/issues/137. The issue seems to be that ruby 2.0 from 1.9.3 and 2.1 behaves differently when trying to pack an array of strings from ENV.
cc @adamedx @btm @randomcamel 
