### PR TITLE
enables to install fonts via cookbook files

### DIFF
--- a/resources/font.rb
+++ b/resources/font.rb
@@ -22,12 +22,4 @@ actions :install
 
 default_action :install
 
-attribute :name, :kind_of => String
-attribute :file, :kind_of => String
-
-# Covers 0.10.8 and earlier
-def initialize(*args)
-  super
-  @action = :install
-  @file ||= @name
-end
+attribute :file, :kind_of => String, :name_attribute => true


### PR DESCRIPTION
Adding font provider for installation of fonts via cookbook files.
Simply add the font into your cookbook files, depend on the windows cookbook and target the windows_font "your_font.ttf" within your recipe.
