### PR TITLE
Windows Features - dism provider - New ohai plugin - Increased future run speed - why_run? now supported for features_dism.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,3 +22,7 @@ default['windows']['allow_pending_reboots'] = true
 default['windows']['allow_reboot_on_failure'] = false
 default['windows']['rubyzipversion'] = nil
 default['windows']['reboot_timeout'] = 60
+
+# Needed for ohai features plugin
+
+default['windows']['ohai_plugins_path'] = 'c:/chef/ohai_plugins'

--- a/files/default/features.rb
+++ b/files/default/features.rb
@@ -1,0 +1,20 @@
+Ohai.plugin(:Features) do
+  provides "installed_features"
+  collect_data(:default) do
+    installed_features Mash.new
+    # Grab raw feature information
+    raw_list_of_features = shell_out("C:\\Windows\\sysnative\\dism.exe /Get-Features /Online /Format:Table").stdout
+    # Remove Quotes and Split into an array
+    features_list = raw_list_of_features.split("\r\n")
+    features_list.each do | feature_details_raw |
+    # Check for Enabled or Enable Pending (Reboot Needed)
+      if ( feature_details_raw =~ /Enabled/ ||  feature_details_raw =~ /Enable Pending/ )
+        feature_details_raw = feature_details_raw.gsub(/\s/,'')
+        feature_details = feature_details_raw.split("|")
+        feature_details.each do | name |
+          installed_features[name.strip] = "Enabled"
+        end
+      end
+    end
+  end
+end

--- a/libraries/feature_base.rb
+++ b/libraries/feature_base.rb
@@ -1,35 +1,61 @@
+#
+# Author:: Wade Peacock (<wade.peacock@visioncritical.com>)
+# Original Author:: ???
+# Cookbook Name:: windows
+# Library:: feature_base
+#
+# Copyright:: 2011, Opscode, Inc.
+# Copyright:: 2015, Vision Critical, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 class Chef
   class Provider
     class WindowsFeature
       module Base
 
+        def whyrun_supported?
+          true
+        end
+
         def action_install
           unless installed?
-            install_feature(@new_resource.feature_name)
-            @new_resource.updated_by_last_action(true)
-            Chef::Log.info("#{@new_resource} installed feature")
-          else
-            Chef::Log.debug("#{@new_resource} is already installed - nothing to do")
+            converge_by("Install Feature - #{ @new_resource }") do
+              install_feature(@new_resource.feature_name)
+              @new_resource.updated_by_last_action(true)
+              Chef::Log.info("#{@new_resource} installed feature")
+            end
           end
         end
 
         def action_remove
           if installed?
-            remove_feature(@new_resource.feature_name)
-            @new_resource.updated_by_last_action(true)
-            Chef::Log.info("#{@new_resource} removed")
-          else
-            Chef::Log.debug("#{@new_resource} feature does not exist - nothing to do")
+            converge_by("Remove Feature - #{ @new_resource }") do
+              remove_feature(@new_resource.feature_name)
+              @new_resource.updated_by_last_action(true)
+              Chef::Log.info("#{@new_resource} removed")
+            end
           end
         end
 
         def action_delete
           if available?
-            delete_feature(@new_resource.feature_name)
-            @new_resource.updated_by_last_action(true)
-            Chef::Log.info("#{@new_resource} deleted")
-          else
-            Chef::Log.debug("#{@new_resource} feature is not installed - nothing to do")
+            converge_by("Delete Feature - #{ @new_resource }") do
+              delete_feature(@new_resource.feature_name)
+              @new_resource.updated_by_last_action(true)
+              Chef::Log.info("#{@new_resource} deleted")
+            end
           end
         end
 
@@ -56,4 +82,3 @@ class Chef
     end
   end
 end
-      

--- a/providers/feature_dism_ohai.rb
+++ b/providers/feature_dism_ohai.rb
@@ -1,0 +1,79 @@
+#
+# Author:: Wade Peacock (<wade.peacock@visioncritical.com>)
+# Original Author:: Seth Chisamore (<schisamo@opscode.com>)
+# Cookbook Name:: windows
+# Provider:: feature_dism_ohai
+# Original Provider:: feature_dism
+#
+# Copyright:: 2011, Opscode, Inc.
+# Copyright:: 2015, Vision Critical Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# https://docs.chef.io/lwrp_custom_provider.html#use-inline-resources
+use_inline_resources
+
+include Chef::Provider::WindowsFeature::Base
+include Chef::Mixin::ShellOut
+include Windows::Helper
+
+def install_feature(name)
+  addsource = @new_resource.source ? "/LimitAccess /Source:\"#{@new_resource.source}\"" : ""
+  addall = @new_resource.all ? "/All" : ""
+  shell_out!("#{dism} /online /enable-feature /featurename:#{@new_resource.feature_name} /norestart #{addsource} #{addall}", {:returns => [0,42,127,3010]})
+  reload_ohai_features_plugin
+end
+
+def remove_feature(name)
+  shell_out!("#{dism} /online /disable-feature /featurename:#{@new_resource.feature_name} /norestart", {:returns => [0,42,127,3010]})
+  reload_ohai_features_plugin
+end
+
+def delete_feature(name)
+  if win_version.major_version >= 6 and win_version.minor_version >=2
+    shell_out!("#{dism} /online /disable-feature /featurename:#{@new_resource.feature_name} /Remove /norestart", {:returns => [0,42,127,3010]})
+    reload_ohai_features_plugin
+  else
+    raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} :delete action not support on #{win_version.sku}"
+  end
+end
+
+def installed?
+  @installed ||= begin
+    node['installed_features'].has_key?(@new_resource.feature_name)
+  end
+end
+
+def available?
+  @available ||= begin
+    cmd = shell_out("#{dism} /online /Get-Features", {:returns => [0,42,127]})
+    cmd.stderr.empty? && (cmd.stdout !~  /^Feature Name : #{@new_resource.feature_name}.?$\n^State : .* with payload removed.?$/i)
+  end
+end
+
+def reload_ohai_features_plugin
+  ohai "reload_installed_features" do
+    action :reload
+    plugin "installed_features"
+  end
+end
+
+private
+# account for File System Redirector
+# http://msdn.microsoft.com/en-us/library/aa384187(v=vs.85).aspx
+def dism
+  @dism ||= begin
+    locate_sysnative_cmd("dism.exe")
+  end
+end

--- a/recipes/features_ohai_plugin.rb
+++ b/recipes/features_ohai_plugin.rb
@@ -1,0 +1,27 @@
+#
+# Cookbook Name:: windows
+# Recipe:: features_ohai_plugin
+#
+# Author:: Wade Peacock (<wade.peacock@visioncritical.com>)
+# Copyright 2015, Vision Critical, Inc
+#
+# All rights reserved - Do Not Redistribute
+#
+
+# This requires your client.rb on the nodes to have the Ohai::Config[:plugin_path] configured
+
+directory node['windows']['ohai_plugins_path'] do
+  action :create
+  recursive true
+end
+
+cookbook_file "#{node['windows']['ohai_plugins_path']}/features.rb" do
+  source "features.rb"
+  # Not supported for Windows 2003 Server/Windows 2003 Server R2
+  not_if { win_version.windows_server_2003_r2? || win_version.windows_server_2003? }
+  notifies :reload, "ohai[installed_features]", :immediately
+end
+
+ohai "installed_features" do
+  action :nothing
+end

--- a/resources/feature.rb
+++ b/resources/feature.rb
@@ -37,7 +37,14 @@ def locate_default_provider
   if  node['windows'].attribute?(:feature_provider)
     "windows_feature_#{node['windows']['feature_provider']}"
   elsif ::File.exists?(locate_sysnative_cmd('dism.exe'))
-    :windows_feature_dism
+    # Check to see if ohai node["installed_features"] is present.
+    # If not use stock dism provider
+    unless node.has_key?("installed_features")
+      :windows_feature_dism
+    # If present use new dism ohai provider
+    else
+      :windows_feature_dism_ohai
+    end
   elsif ::File.exists?(locate_sysnative_cmd('servermanagercmd.exe'))
     :windows_feature_servermanagercmd
   end


### PR DESCRIPTION
Added custom ohai plugin to collect installed windows features
Added new provider that uses ohai plugin to determine whether features
are installed.
Changed library feature_base to dynamically use dism_ohai provider if
node attribute object is present
Added recipe to place ohai plugin in ohai_plugins folder on client
Added proper why_run? handling for dism features