### PR TITLE
Make auto_run's root registry key configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ As of chef-client 13.0+ and 13.4+ windows_task and windows_path are now included
 - `name` - Name attribute. The name of the value to be stored in the registry
 - `program` - The program to be run at login
 - `args` - The arguments for the program
+- `root` - The registry root key to put the entry under--`:machine` (default) or `:user`
 
 #### Examples
 

--- a/resources/auto_run.rb
+++ b/resources/auto_run.rb
@@ -22,9 +22,14 @@
 property :program, String
 property :name, String, name_property: true
 property :args, String
+property :root,
+         Symbol,
+         equal_to: %i(machine user),
+         coerce: proc { |x| x.to_sym },
+         default: :machine
 
 action :create do
-  registry_key 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run' do
+  registry_key registry_path do
     values [{
       name: new_resource.name,
       type: :string,
@@ -35,12 +40,19 @@ action :create do
 end
 
 action :remove do
-  registry_key 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run' do
+  registry_key registry_path do
     values [{
       name: new_resource.name,
       type: :string,
       data: '',
     }]
     action :delete
+  end
+end
+
+action_class do
+  def registry_path
+    { machine: 'HKLM', user: 'HKCU' }[new_resource.root] + \
+      '\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run'
   end
 end

--- a/test/cookbooks/test/recipes/autorun.rb
+++ b/test/cookbooks/test/recipes/autorun.rb
@@ -1,11 +1,19 @@
 windows_auto_run 'add notepad' do
   name 'notepad'
   program 'C:/windows/system32/notepad.exe'
-  action  :create
+  action :create
 end
 
 windows_auto_run 'remove notepad' do
   name 'notepad'
   program 'C:/windows/system32/notepad.exe'
-  action  :remove
+  root :machine
+  action :remove
+end
+
+windows_auto_run 'add wordpad' do
+  name 'wordpad'
+  program 'C:\Windows\System32\write.exe'
+  root 'user'
+  action :create
 end

--- a/test/integration/autorun/pester/minimal.autorun.Tests.ps1
+++ b/test/integration/autorun/pester/minimal.autorun.Tests.ps1
@@ -1,0 +1,15 @@
+$global:progressPreference = 'SilentlyContinue'
+
+describe 'test::autorun' {
+  context 'windows_auto_run' {
+    it "does not auto-run Notepad for the machine" {
+      $path = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
+      (Get-ItemProperty -Path $path).notepad | Should Be $Null
+    }
+
+    it "auto-runs Wordpad for the current user" {
+      $path = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
+      (Get-ItemProperty -Path $path).wordpad | Should Be '"C:\Windows\System32\write.exe" '
+    }
+  }
+}


### PR DESCRIPTION
I recently found myself working on a cookbook for an app that only installs on
a per-user basis, putting all its registry entries under the
`HKEY_CURRENT_USER` root key instead of `HKEY_LOCAL_MACHINE`.

This change adds a `root` property to the `windows_auto_run` resource,
maintaining the current behavior as a default and allowing support for
user-level applications as well.

Signed-off-by: Jonathan Hartman <j@hartman.io>