### PR TITLE
Adds support for tasks triggering off event logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the windows cookbook.
 Unreleased
 --------------------
 - Do not set new_resource.password to nil, Fixes #219, Fixes #220
+- add support for triggering tasks off event logs.
 
 v1.37.0 (2015-05-14)
 --------------------

--- a/README.md
+++ b/README.md
@@ -636,6 +636,8 @@ Server 2008 due to API usage.
 #### Attribute Parameters
 - task_name: name attribute, The task name. ("Task Name" or "/Task Name")
 - force: When used with create, will update the task.
+- channel_name: Specifies an eventlog channel name for triggering tasks.
+- event_modifier: Specifies an eventlog modifier for triggering tasks.
 - command: The command the task will run.
 - cwd: The directory the task will be run from.
 - user: The user to run the task as. (defaults to 'SYSTEM')

--- a/providers/task.rb
+++ b/providers/task.rb
@@ -45,6 +45,8 @@ action :create do
     options['RL'] = 'HIGHEST' if @new_resource.run_level == :highest
     options['IT'] = '' if @new_resource.interactive_enabled
     options['D'] = @new_resource.day if @new_resource.day
+    options['EC'] = "\"#{@new_resource.channel_name}\" " unless @new_resource.channel_name.nil?
+  	options['MO'] = "\"#{@new_resource.event_modifier}\" " unless @new_resource.event_modifier.nil?
 
     run_schtasks 'CREATE', options
     new_resource.updated_by_last_action true

--- a/resources/task.rb
+++ b/resources/task.rb
@@ -24,8 +24,10 @@ actions :create, :delete, :run, :end, :change, :enable, :disable
 
 
 attribute :task_name, :kind_of => String, :name_attribute => true, :regex => [ /\A[^\/\:\*\?\<\>\|]+\z/ ]
+attribute :channel_name, :kind_of => String, :default => nil
 attribute :command, :kind_of => String
 attribute :cwd, :kind_of => String
+attribute :event_modifier, :kind_of => String, :default => nil
 attribute :user, :kind_of => String, :default => 'SYSTEM'
 attribute :password, :kind_of => String, :default => nil
 attribute :run_level, :equal_to => [:highest, :limited], :default => :limited


### PR DESCRIPTION
This pull request adds support for setting up a task that is triggered from a Windows event log.
