### PR TITLE
Lazy load windows-pr dependency

### DIFF
--- a/libraries/windows_privileged.rb
+++ b/libraries/windows_privileged.rb
@@ -20,24 +20,14 @@
 # limitations under the License.
 #
 
-if RUBY_PLATFORM =~ /mswin|mingw32|windows/
-  require 'windows/error'
-  require 'windows/registry'
-  require 'windows/process'
-  require 'windows/security'
-end
-
 #helpers for Windows API calls that require privilege adjustments
 class Chef
   class WindowsPrivileged
-    if RUBY_PLATFORM =~ /mswin|mingw32|windows/
-      include Windows::Error
-      include Windows::Registry
-      include Windows::Process
-      include Windows::Security
-    end
+
     #File -> Load Hive... in regedit.exe
     def reg_load_key(name, file)
+      load_deps
+
       run(SE_BACKUP_NAME, SE_RESTORE_NAME) do
         rc = RegLoadKey(HKEY_USERS, name.to_s, file)
         if rc == ERROR_SUCCESS
@@ -52,6 +42,8 @@ class Chef
 
     #File -> Unload Hive... in regedit.exe
     def reg_unload_key(name)
+      load_deps
+
       run(SE_BACKUP_NAME, SE_RESTORE_NAME) do
         rc = RegUnLoadKey(HKEY_USERS, name.to_s)
         if rc != ERROR_SUCCESS
@@ -61,6 +53,8 @@ class Chef
     end
 
     def run(*privileges)
+      load_deps
+
       token = [0].pack('L')
 
       unless OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES|TOKEN_QUERY, token)
@@ -84,10 +78,27 @@ class Chef
     end
 
     def adjust_privilege(token, priv, attr=0)
+      load_deps
+
       luid = [0,0].pack('Ll')
       if LookupPrivilegeValue(nil, priv, luid)
         new_state = [1, luid.unpack('Ll'), attr].flatten.pack('LLlL')
         AdjustTokenPrivileges(token, 0, new_state, new_state.size, 0, 0)
+      end
+    end
+
+    private
+    def load_deps
+      if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+	require 'windows/error'
+	require 'windows/registry'
+	require 'windows/process'
+	require 'windows/security'
+
+	include Windows::Error
+	include Windows::Registry
+	include Windows::Process
+	include Windows::Security
       end
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache 2.0'
 description      'Provides a set of useful Windows-specific primitives.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.38.1'
+version          '1.38.2'
 supports         'windows'
 source_url       'https://github.com/chef-cookbooks/windows' if respond_to?(:source_url)
 issues_url       'https://github.com/chef-cookbooks/windows/issues' if respond_to?(:issues_url)


### PR DESCRIPTION
Resolves https://github.com/chef-cookbooks/windows/issues/276

Chef (client) 12.5 no longer ships with the windows-pr gem. This cookbook includes the windows-pr gem but the windows/* libraries were being loaded from the windows-pr gem shipping with Chef. This lazy-loads the windows/* libraries so the cookbook can compile.