### PR TITLE
Lazy load windows-pr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ windows Cookbook CHANGELOG
 =======================
 This file is used to list changes made in each version of the windows cookbook.
 
+v1.38.2 (unreleased)
+--------------------
+- Lazy-load windows-pr gem library files. Chef 12.5 no longer includes the windows-pr gem. Earlier versions of this cookbook will not compile on Chef 12.5.
+
 v1.38.1 (2015-07-28)
 --------------------
 - Publishing without extended metadata

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache 2.0'
 description      'Provides a set of useful Windows-specific primitives.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.38.1'
+version          '1.38.2'
 supports         'windows'
 source_url       'https://github.com/chef-cookbooks/windows' if respond_to?(:source_url)
 issues_url       'https://github.com/chef-cookbooks/windows/issues' if respond_to?(:issues_url)


### PR DESCRIPTION
Resolves https://github.com/chef-cookbooks/windows/issues/276

Lazy loads windows-pr libraries. Chef 12.5 no longer includes the windows-pr gem, which is where these files were actually being loaded from (not from the `chef_gem 'windows-pr`').

