### PR TITLE
added share LWRP

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -50,3 +50,7 @@ suites:
     run_list:
       - recipe[windows::default]
       - recipe[minimal::package]
+  - name: share
+    run_list:
+      - recipe[windows::default]
+      - recipe[minimal::share]

--- a/README.md
+++ b/README.md
@@ -574,6 +574,38 @@ windows_registry 'HKCU\Software\Test' do
 end
 ```
 
+### windows_share
+Creates, modifies and removes Windows shares. All properties are idempotent.
+
+#### Actions
+- :create: creates/modifies a share
+- :delete: deletes a share
+
+#### Attribute Parameters
+- share_name: name attribute, the share name.
+- path: path to the directory to be shared. Required when creating. If the share already exists on a different path then it is deleted and re-created.
+- description: description to be applied to the share
+- full_users: array of users which should have "Full control" permissions
+- change_users: array of users which should have "Change" permissions
+- read_users: array of users which should have "Read" permissions
+
+#### Examples
+
+```ruby
+windows_share "foo" do
+  action :create
+  path "C:\\foo"
+  full_users ["DOMAIN_A\\some_user", "DOMAIN_B\\some_other_user"]
+  read_users ["DOMAIN_C\\Domain users"]
+end
+```
+
+```ruby
+windows_share "foo" do
+  action :delete
+end
+```
+
 ### windows_shortcut
 Creates and modifies Windows shortcuts.
 

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -18,6 +18,7 @@ if defined?(ChefSpec)
   define_method.call :windows_printer
   define_method.call :windows_printer_port
   define_method.call :windows_reboot
+  define_method.call :windows_share
   #
   # Assert that a +windows_package+ resource exists in the Chef run with the
   # action +:install+. Given a Chef Recipe that installs "Node.js" as a
@@ -422,6 +423,56 @@ if defined?(ChefSpec)
   #
   def zip_windows_zipfile_to(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:windows_zipfile, :zip, resource_name)
+  end
+
+  #
+  # Assert that a +windows_share+ resource exists in the Chef run with the
+  # action +:create+. Given a Chef Recipe that shares "c:/src"
+  # as Src
+  #
+  #     windows_share "Src" do
+  #       path "c:/src"
+  #       action :create
+  #     end
+  #
+  # The Examples section demonstrates the different ways to test a
+  # +windows_share+ resource with ChefSpec.
+  #
+  # @example Assert that a +windows_share+ was created
+  #   expect(chef_run).to create_windows_share('Src')
+  #
+  #
+  # @param [String, Regex] resource_name
+  #   the name of the resource to match
+  #
+  # @return [ChefSpec::Matchers::ResourceMatcher]
+  #
+  def create_windows_share(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:windows_share, :create, resource_name)
+  end
+
+  #
+  # Assert that a +windows_share+ resource exists in the Chef run with the
+  # action +:delete+. Given a Chef Recipe that deletes share "c:/src"
+  #
+  #     windows_share "Src" do
+  #       action :delete
+  #     end
+  #
+  # The Examples section demonstrates the different ways to test a
+  # +windows_share+ resource with ChefSpec.
+  #
+  # @example Assert that a +windows_share+ was created
+  #   expect(chef_run).to delete_windows_share('Src')
+  #
+  #
+  # @param [String, Regex] resource_name
+  #   the name of the resource to match
+  #
+  # @return [ChefSpec::Matchers::ResourceMatcher]
+  #
+  def delete_windows_share(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:windows_share, :delete, resource_name)
   end
 
 

--- a/providers/share.rb
+++ b/providers/share.rb
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+#
+# Author:: Sölvi Páll Ásgeirsson (<solvip@gmail.com>), Richard Lavey (richard.lavey@calastone.com)
+# Cookbook Name:: windows
+# Provider:: share
+#
+# Copyright:: 2014, Sölvi Páll Ásgeirsson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+include Windows::Helper
+
+require 'win32ole'
+
+ACCESS_FULL = 2032127
+ACCESS_CHANGE = 1245631
+ACCESS_READ = 1179817
+
+# Support whyrun
+def whyrun_supported?
+  true
+end
+
+action :delete do
+  if @current_resource.exists
+    converge_by("Deleting #{@current_resource.share_name}") do
+      delete_share
+    end
+  else
+    Chef::Log.debug("#{@current_resource.share_name} does not exist - nothing to do")
+  end
+end
+
+action :create do
+  raise "No path property set" unless @new_resource.path
+
+  if @current_resource.exists
+    recreateRequired = (@current_resource.path.casecmp(win_friendly_path(@new_resource.path)) != 0)
+    
+    # note that we downcase the new user arrays so they match the lower case current values
+    needsChange = recreateRequired ||
+      (@current_resource.description != @new_resource.description)
+      (@current_resource.full_users.count != @new_resource.full_users.count) ||
+      (@current_resource.change_users.count != @new_resource.change_users.count) ||
+      (@current_resource.read_users.count != @new_resource.read_users.count) ||
+      !(@current_resource.full_users - @new_resource.full_users.map(&:downcase)).empty? ||
+      !(@current_resource.change_users - @new_resource.change_users.map(&:downcase)).empty? ||
+      !(@current_resource.read_users - @new_resource.read_users.map(&:downcase)).empty?
+      
+    if needsChange
+      converge_by("Changing #{@current_resource.share_name}") do
+        if recreateRequired
+          delete_share
+          create_share
+        end
+        
+        set_share_permissions
+      end
+    else
+      Chef::Log.debug("#{@current_resource.share_name} already set - nothing to do")
+    end
+  else
+    converge_by("Creating #{@current_resource.share_name}") do
+      create_share
+      set_share_permissions
+    end
+  end
+end
+
+def load_current_resource
+  @current_resource = Chef::Resource::WindowsShare.new(@new_resource.name)
+  @current_resource.share_name(@new_resource.share_name)
+  
+  share = find_share_by_name (@current_resource.share_name)
+
+  if share.nil?
+    @current_resource.exists = false
+  else
+    @current_resource.exists = true
+    @current_resource.path(share.Path)
+    @current_resource.description(share.Description)
+    get_share_permissions
+  end  
+end
+
+private
+
+def get_share_permissions
+  wmi = WIN32OLE.connect("winmgmts://")
+  shares = wmi.ExecQuery("SELECT * FROM Win32_LogicalShareSecuritySetting WHERE name = '#{@current_resource.share_name}'")
+  
+  # The security descriptor is an output parameter
+  sd = nil
+  shares.ItemIndex(0).GetSecurityDescriptor(sd)
+  sd = WIN32OLE::ARGV[0]
+  
+  read = []
+  change = []
+  full = []
+  for dacl in sd.DACL do
+    trustee = "#{dacl.Trustee.Domain}\\#{dacl.Trustee.Name}".downcase
+    case dacl.AccessMask
+      when ACCESS_FULL
+        full.push(trustee)
+      when ACCESS_CHANGE
+        change.push(trustee)
+      when ACCESS_READ
+        read.push(trustee)
+      else
+        Chef::Log.warn "Unknown access mask #{dacl.AccessMask} for user #{trustee}. This will be lost if permissions are updated"
+    end
+  end
+
+  @current_resource.full_users(full)
+  @current_resource.change_users(change)
+  @current_resource.read_users(read)
+end
+
+def find_share_by_name(name)
+  wmi = WIN32OLE.connect("winmgmts://")
+  shares = wmi.ExecQuery("SELECT * FROM Win32_Share WHERE name = '#{name}'")
+  shares.Count == 0 ? nil : shares.ItemIndex(0)
+end
+
+def delete_share
+  find_share_by_name(@new_resource.share_name).delete
+end
+  
+def create_share
+  raise "#{@new_resource.path} is missing or not a directory" unless ::File.directory? @new_resource.path
+  
+  # http://msdn.microsoft.com/en-us/library/aa389393(v=vs.85).aspx
+  wmi = WIN32OLE.connect("winmgmts://")
+  share = wmi.get("Win32_Share")
+  r = share.create(win_friendly_path(@new_resource.path), # Path
+                   @new_resource.share_name, # Share name
+                   0, # Share type 0 = Disk
+                   16777216, # Maximum allowed.  This is the 2008 R2 default.
+                   @new_resource.description, # The description
+                   nil, # The share password, unused.
+                   nil) # The share security descriptor
+
+  
+  raise "Could not create share.  Win32_Share.create returned #{r}" unless r == 0
+end
+
+# set_share_permissions - Enforce the share permissions as dictated by the resource attributes
+def set_share_permissions
+  wmi = WIN32OLE.connect("winmgmts://")
+  dacl = []
+  
+  @new_resource.full_users.each do |user|
+    dacl.push(user_to_ace(wmi, user, ACCESS_FULL))
+  end
+
+  @new_resource.change_users.each do |user|
+    dacl.push(user_to_ace(wmi, user, ACCESS_CHANGE))
+  end
+
+  @new_resource.read_users.each do |user|
+    dacl.push(user_to_ace(wmi, user, ACCESS_READ))
+  end
+  
+  security_descriptor = wmi.get("Win32_SecurityDescriptor")
+  security_descriptor.DACL = dacl
+  
+  share = find_share_by_name(@new_resource.share_name)
+  share.SetShareInfo(nil, @new_resource.description, security_descriptor)
+end
+
+def user_to_ace(wmi, fully_qualified_user_name, access)
+  
+  domain, user = fully_qualified_user_name.split("\\")
+  unless domain and user
+    raise "Invalid user entry #{fully_qualified_user_name}.  The user names must be specified as 'DOMAIN\\user'"
+  end
+  
+  ace = wmi.get("Win32_ACE")
+  trustee = wmi.get("Win32_Trustee")
+  trustee.Name = user
+  trustee.Domain = domain
+  
+  ace.AccessMask = access
+  ace.AceFlags = 3 # OBJECT_INHERIT_ACE + CONTAINER_INHERIT_ACE
+  ace.AceType = 0 # 0 allow, 1 deny
+  ace.Trustee = trustee
+  
+  ace
+end

--- a/resources/share.rb
+++ b/resources/share.rb
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# Author:: Sölvi Páll Ásgeirsson (<solvip@gmail.com>), Richard Lavey (richard.lavey@calastone.com)
+# Cookbook Name:: windows
+# Resource:: share
+#
+# Copyright:: 2014, Sölvi Páll Ásgeirsson.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create, :delete
+default_action :create
+
+attribute :share_name, :kind_of => String, :name_attribute => true, :required => true
+attribute :path, :kind_of => String
+attribute :description, :kind_of => String, :default => ''
+attribute :full_users, :kind_of => Array, :default => []
+attribute :change_users, :kind_of => Array, :default => []
+attribute :read_users, :kind_of => Array, :default => []
+
+attr_accessor :exists

--- a/test/cookbooks/minimal/recipes/share.rb
+++ b/test/cookbooks/minimal/recipes/share.rb
@@ -1,0 +1,40 @@
+
+# create directory for sharing with full access for all users
+directory "c:/test_share" do
+    rights  :full_control, "BUILTIN\\Users"
+end
+
+windows_share "read_only" do
+    path            "C:/test_share"
+    description     "a test share"
+    read_users      ["BUILTIN\\Users"]
+end
+
+windows_share "change" do
+    path            "C:/test_share"
+    change_users    ["BUILTIN\\Users"]
+end
+
+windows_share "full" do
+    path            "C:/test_share"
+    full_users    ["BUILTIN\\Users"]
+end
+
+# create then delete the share
+windows_share "create no_share" do
+    share_name      "no_share"
+    path            "C:/test_share"
+end
+windows_share "no_share" do
+    action          :delete
+end
+
+# create share then change path
+windows_share "create changed_dir" do
+    share_name      "changed_dir"
+    path            "C:/"
+end
+windows_share "alter changed_dir" do
+    share_name      "changed_dir"
+    path            "C:/test_share"
+end

--- a/test/integration/share/pester/minimal.share.Tests.ps1
+++ b/test/integration/share/pester/minimal.share.Tests.ps1
@@ -1,0 +1,57 @@
+$global:progressPreference = 'SilentlyContinue'
+
+describe 'minimal::share' {
+  context 'windows_share' {
+    it "creates share read_only"  {
+      "\\localhost\read_only" | Should Exist
+    }
+    
+    it "sets description"  {
+      $s = net share | Out-String
+      $s | Should Match "read_only\s*c:\\test_share\s*a test share"
+    }
+    
+    it "permisisons read_only to prevent write"  {
+      $f = New-Item "\\localhost\read_only\bang" -Type File
+      $f | Should BeNullOrEmpty
+    }
+    
+    it "creates share change"  {
+      "\\localhost\change" | Should Exist
+    }
+    
+    $fileName = "\\localhost\change\change_file"
+    it "permisisons change to allow create"  {
+      $f = New-Item $fileName -Type File 
+      $f.Name | Should Be "change_file"
+    }
+    
+    it "permisisons change to allow delete"  {
+      Remove-Item $fileName
+    }
+    
+    it "creates share full"  {
+      "\\localhost\full" | Should Exist
+    }
+    
+    $fileName = "\\localhost\full\change_file"
+    it "permisisons full to allow create"  {
+      $f = New-Item $fileName -Type File 
+      $f.Name | Should Be "change_file"
+    }
+    
+    it "permisisons full to allow delete"  {
+      Remove-Item $fileName
+    }
+    
+    it "removes share no_share"  {
+      "\\localhost\no_share" | Should Not Exist
+    }
+    
+    it "can change the directory associated with a share"  {
+      $s = net share | Out-String
+      $s | Should Match "changed_dir\s*c:\\test_share"
+    }
+    
+  }
+}


### PR DESCRIPTION
There have been 3 previous pull requests for a share LWRP (#73, #87, #135).

This is an enhancement of #73 (thanks @solvip) that makes all the properties idempotent and supports whyrun. It uses WMI via WINOLE rather than the net share command.
