### PR TITLE
frequency_modifier validation & additional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,7 +654,7 @@ Server 2008 due to API usage.
 - password: The user's password. (requires user)
 - run_level: Run with limited or highest privileges.
 - frequency: Frequency with which to run the task. (default is :hourly. Other valid values include :minute, :hourly, :daily, :weekly, :monthly, :once, :on_logon, :onstart, :on_idle) \*:once requires start_time
-- frequency_modifier: Multiple for frequency. (15 minutes, 2 days)
+- frequency_modifier: Multiple for frequency. Valid values are numerical values dependant on the specified frequency (1-1439 for minutes, 1-23 for hours, 1-365 for days, 1-52 for weeks or 1-12 for months) or 'LASTDAY', 'FIRST', 'SECOND', 'THIRD', 'FOURTH' or 'LAST' if targeting a specific week and day.
 - start_day: Specifies the first date on which the task runs. Optional string (MM/DD/YYYY)
 - start_time: Specifies the start time to run the task. Optional string (HH:mm) 24 Hour time
 - interactive_enabled: (Allow task to run interactively or non-interactively.  Requires user and password.)

--- a/providers/task.rb
+++ b/providers/task.rb
@@ -30,6 +30,7 @@ action :create do
     validate_user_and_password
     validate_interactive_setting
     validate_create_day
+    validate_frequency_modifier
 
     schedule  = @new_resource.frequency == :on_logon ? "ONLOGON" : @new_resource.frequency
     frequency_modifier_allowed = [:minute, :hourly, :daily, :weekly, :monthly]
@@ -234,6 +235,31 @@ def validate_create_day
       if not ["mon", "tue", "wed", "thu", "fri", "sat", "sun", "*"].include?(day.strip.downcase) then
         raise "day attribute invalid.  Only valid values are: MON, TUE, WED, THU, FRI, SAT, SUN and *.  Multiple values must be separated by a comma."
       end
+    end
+  end
+end
+
+def validate_frequency_modifier
+  case @new_resource.frequency
+  when :minute
+    unless (1...1439).include?(@new_resource.frequency_modifier)
+      raise "Minute frequency modifier is invalid. Please specifiy a value between 1-1439"
+    end
+  when :hourly
+    unless (1...23).include?(@new_resource.frequency_modifier)
+      raise "Hourly frequency modifier is invalid. Please specifiy a value between 1-23"
+    end
+  when :daily
+    unless (1...365).include?(@new_resource.frequency_modifier)
+      raise "Daily frequency modifier is invalid. Please specifiy a value between 1-365"
+    end
+  when :weekly
+    unless (1...52).include?(@new_resource.frequency_modifier)
+      raise "Weekly frequency modifier is invalid. Please specifiy a value between 1-52"
+    end
+  when :monthly
+    unless (1...12).include?(@new_resource.frequency_modifier) || ["lastday", "first", "second", "third", "fourth", "last"].include?(@new_resource.frequency_modifier.to_s.strip.downcase)
+      raise "Monthly frequency modifier is invalid. Please specifiy a value between 1-12, LASTDAY, FIRST, SECOND, THIRD, FOURTH or LAST."
     end
   end
 end

--- a/resources/task.rb
+++ b/resources/task.rb
@@ -31,7 +31,7 @@ attribute :password, :kind_of => String, :default => nil
 attribute :run_level, :equal_to => [:highest, :limited], :default => :limited
 attribute :force, :kind_of => [ TrueClass, FalseClass ], :default => false
 attribute :interactive_enabled, :kind_of => [ TrueClass, FalseClass ], :default => false
-attribute :frequency_modifier, :kind_of => Integer, :default => 1
+attribute :frequency_modifier, :kind_of => [ String, Integer ], :default => 1
 attribute :frequency, :equal_to => [:minute,
                                     :hourly,
                                     :daily,


### PR DESCRIPTION
I've updated the windows_task provider to validate the `frequency_modifier` attribute to ensure it's a valid value and updated the same resource to allow Strings. This allows you to specify the additional parameters for the `schtasks.exe` switch `/MO` that are string values (LAST, FIRST, SECOND, THIRD, FOURTH, & LAST). 

Feedback welcome on the code if there is a more elegant way to handle this or if I missed anything.