### PR TITLE
Escape http_acl user in shellout

### DIFF
--- a/providers/http_acl.rb
+++ b/providers/http_acl.rb
@@ -83,7 +83,7 @@ def getCurrentAcl
 end
 
 def setAcl
-  shell_out!("#{@command} http add urlacl url=#{@new_resource.url} user=#{@new_resource.user}")
+  shell_out!("#{@command} http add urlacl url=#{@new_resource.url} user=\"#{@new_resource.user}\"")
 end
 
 def deleteAcl


### PR DESCRIPTION
Current `http_acl` implementation fail when username contains space(s).
Surrounding the netsh param with double quotes fix the issue.

cc. @aboten