### PR TITLE
windows_certificate_binding is ignoring store_name attribute

### DIFF
--- a/chefignore
+++ b/chefignore
@@ -97,3 +97,5 @@ Vagrantfile
 # Travis #
 ##########
 .travis.yml
+
+.kitchen

--- a/providers/certificate_binding.rb
+++ b/providers/certificate_binding.rb
@@ -66,6 +66,7 @@ def load_current_resource
   @current_resource.name_kind(@new_resource.name_kind)
   @current_resource.address(@new_resource.address)
   @current_resource.port(@new_resource.port)
+  @current_resource.store_name(@new_resource.store_name)
 
   @command = locate_sysnative_cmd('netsh.exe')
   getCurrentHash

--- a/test/cookbooks/minimal/recipes/certificate.rb
+++ b/test/cookbooks/minimal/recipes/certificate.rb
@@ -19,4 +19,10 @@ end
 windows_certificate "#{Chef::Config[:file_cache_path]}/cookbooks/minimal/files/default/test-cert.pfx" do
   action :create
   pfx_password 'chef123'
+  store_name 'CA'
+end
+
+windows_certificate_binding 'ChefDummyCertForTest' do
+  store_name 'CA'
+  port 443
 end

--- a/test/integration/certificate/pester/minimal.certificate.Tests.ps1
+++ b/test/integration/certificate/pester/minimal.certificate.Tests.ps1
@@ -12,14 +12,20 @@ describe 'minimal::certificate' {
     }
 
     it "installs test-cert" {
-      "Cert:\LocalMachine\My\5081f667f1ef005d0ec39fa3e30aa71b4fd84eb6" | Should Exist
+      "Cert:\LocalMachine\CA\5081f667f1ef005d0ec39fa3e30aa71b4fd84eb6" | Should Exist
     }
 
     it "puts persists the private key for test-cert" {
-      $cert = Get-ChildItem "Cert:\LocalMachine\My\5081f667f1ef005d0ec39fa3e30aa71b4fd84eb6"
+      $cert = Get-ChildItem "Cert:\LocalMachine\CA\5081f667f1ef005d0ec39fa3e30aa71b4fd84eb6"
       $cert.PrivateKey.CspKeyContainerInfo.MachineKeyStore | Should Be True
       $uniqueName = $cert.PrivateKey.CspKeyContainerInfo.UniqueKeyContainerName
       "$Env:ProgramData\Microsoft\Crypto\RSA\MachineKeys\$uniqueName" | Should Exist
+    }
+
+    it "binds test-cert to port 443" {
+      $binding = netsh http show sslcert
+      $binding[4] | Should Match ' : 0.0.0.0:443$'
+      $binding[5] | Should Match ' : 5081f667f1ef005d0ec39fa3e30aa71b4fd84eb6$'
     }
   }
 }


### PR DESCRIPTION
This fixes issues as reported in #298 where the `store_name` of `windows_certificate_binding` is ignored and always uses `MY` regardless of attribute value.