### PR TITLE
Task enhancements

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'cookbooks@getchef.com'
 license          'Apache 2.0'
 description      'Provides a set of useful Windows-specific primitives.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.37.0'
+version          '1.36.99'
 supports         'windows'
 depends          'chef_handler'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'cookbooks@getchef.com'
 license          'Apache 2.0'
 description      'Provides a set of useful Windows-specific primitives.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.36.1'
+version          '1.37.0'
 supports         'windows'
 depends          'chef_handler'

--- a/resources/task.rb
+++ b/resources/task.rb
@@ -29,7 +29,7 @@ attribute :user, :kind_of => String, :default => nil
 attribute :password, :kind_of => String, :default => nil
 attribute :run_level, :equal_to => [:highest, :limited], :default => :limited
 attribute :force, :kind_of => [ TrueClass, FalseClass ], :default => false
-attribute :frequency_modifier, :kind_of => Integer, :default => 1
+attribute :frequency_modifier, :kind_of => [Integer, String], :default => 1
 attribute :frequency, :equal_to => [:minute,
                                     :hourly,
                                     :daily,

--- a/resources/task.rb
+++ b/resources/task.rb
@@ -42,6 +42,7 @@ attribute :frequency, :equal_to => [:minute,
 attribute :start_day, :kind_of => String, :default => nil
 attribute :start_time, :kind_of => String, :default => nil
 attribute :day, :kind_of => [ String, Integer ], :default => nil
+attribute :months, :kind_of => String, :default => nil
 
 attr_accessor :exists, :status, :enabled
 


### PR DESCRIPTION
Sorry if this is incorrect, I'm fairly new to this. But this is a fairly nice enhancement to the windows_task resource that allows for selecting specific months to run a task as well as setting frequency modifier to accept specific strings so you can do things like 3rd tuesday of the month. This was originally developed to help us schedule our patching script for 3rd tuesday of every month except in december to meet our patching policy schedule.