### PR TITLE
Fix http_acl regex to capture username with space

### DIFF
--- a/providers/http_acl.rb
+++ b/providers/http_acl.rb
@@ -73,7 +73,7 @@ def getCurrentAcl
   cmd = shell_out!("#{@command} http show urlacl url=#{@current_resource.url}")
   Chef::Log.debug "netsh reports: #{cmd.stdout}"
 
-  m = cmd.stdout.scan(/User:\s*(\S+)/)
+  m = cmd.stdout.scan(/User:\s*(.+)/)
   if m.length == 0
     @current_resource.exists = false
   else


### PR DESCRIPTION
With #295 http_acl LWRP now supports username with spaces, but due to the current regex to capture username, the execution is not idempotent.
Changing the regex to capture everything after space characters fix it.

cc: @aboten