### PR TITLE
Provide helper method to get windows version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,47 @@ if is_package_installed?('Windows Software Development Kit')
 end
 ```
 
+### Windows::VersionHelper
+
+Helper that allows you to get information of the windows version running on your node.
+It leverages windows ohai from kernel.os_info, easy to mock and to use even on linux.
+
+#### core_version?
+Determines whether given node is running on a windows Core.
+```ruby
+if ::Windows::VersionHelper.core_version? node
+  fail 'Windows Core is not supported'
+end
+```
+
+#### workstation_version?
+Determines whether given node is a windows workstation version (XP, Vista, 7, 8, 8.1, 10)
+```ruby
+if ::Windows::VersionHelper.workstation_version? node
+  fail 'Only server version of windows are supported'
+end
+```
+
+#### server_version?
+Determines whether given node is a windows server version (Server 2003, Server 2008, Server 2012, Server 2016)
+```ruby
+if ::Windows::VersionHelper.server_version? node
+  puts 'Server version of windows are cool'
+end
+```
+
+#### nt_version
+Determines NT version of the given node
+```ruby
+case ::Windows::VersionHelper.nt_version node
+  when '6.0' then 'Windows vista or Server 2008'
+  when '6.1' then 'Windows 7 or Server 2008R2'
+  when '6.2' then 'Windows 8 or Server 2012'
+  when '6.3' then 'Windows 8.1 or Server 2012R2'
+  when '10.0' then 'Windows 10'
+end
+```
+
 ## Windows ChefSpec Matchers
 
 The Windows cookbook includes custom [ChefSpec](https://github.com/sethvargo/chefspec) matchers you can use to test your own cookbooks that consume Windows cookbook LWRPs.

--- a/libraries/version_helper.rb
+++ b/libraries/version_helper.rb
@@ -1,0 +1,79 @@
+#
+# Cookbook Name:: windows
+# Library:: version_helper
+# Author:: Baptiste Courtois (<b.courtois@criteo.com>)
+#
+# Copyright (C) 2015 Criteo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module Windows
+  # Module based on windows ohai kernel.cs_info providing version helpers
+  module VersionHelper
+    # Module referencing CORE SKU contants from product type
+    # see. https://msdn.microsoft.com/windows/desktop/ms724358#PRODUCT_DATACENTER_SERVER_CORE
+    # n.b. Prefix - PRODUCT_ - and suffix - _CORE- have been removed
+    module CoreSKU
+      # Server Datacenter Core
+      DATACENTER_SERVER   = 0x0C unless defined?(DATACENTER_SERVER)
+      # Server Datacenter without Hyper-V Core
+      DATACENTER_SERVER_V = 0x27 unless defined?(DATACENTER_SERVER_V)
+      # Server Enterprise Core
+      ENTERPRISE_SERVER   = 0x0E unless defined?(ENTERPRISE_SERVER)
+      # Server Enterprise without Hyper-V Core
+      ENTERPRISE_SERVER_V = 0x29 unless defined?(ENTERPRISE_SERVER_V)
+      # Server Standard Core
+      STANDARD_SERVER     = 0x0D unless defined?(STANDARD_SERVER)
+      # Server Standard without Hyper-V Core
+      STANDARD_SERVER_V   = 0x28 unless defined?(STANDARD_SERVER_V)
+    end
+
+    # Module referencing product type contants
+    # see. https://msdn.microsoft.com/windows/desktop/ms724833#VER_NT_SERVER
+    # n.b. Prefix - VER_NT_ - has been removed
+    module ProductType
+      WORKSTATION         = 0x1 unless defined?(WORKSTATION)
+      DOMAIN_CONTROLLER   = 0x2 unless defined?(DOMAIN_CONTROLLER)
+      SERVER              = 0x3 unless defined?(SERVER)
+    end
+
+    # Determines whether current node is running a windows Core version
+    def self.core_version?(node)
+      validate_platform node
+
+      CoreSKU.constants.any? { |c| CoreSKU.const_get(c) == node['kernel']['os_info']['operating_system_sku'] }
+    end
+
+    # Determines whether current node is a workstation version
+    def self.workstation_version?(node)
+      validate_platform node
+      node['kernel']['os_info']['product_type'] == ProductType::WORKSTATION
+    end
+
+    # Determines whether current node is a server version
+    def self.server_version?(node)
+      !workstation_version?(node)
+    end
+
+    # Determines NT version of the current node
+    def self.nt_version(node)
+      validate_platform node
+
+      node['platform_version'].to_f
+    end
+
+    def self.validate_platform(node)
+      raise 'Windows helper are only supported on windows platform!' if node['platform'] != 'windows'
+    end
+  end
+end


### PR DESCRIPTION
Add new Windows::VersionHelper module.
These helpers rely on kernel.cs_info ohai instead of Win32 api calls.
Using this helper instead of `WindowsVersion` object, allows you to rspec test your recipes on linux, or just easily mock the version you want to test.

cc: @aboten
