### PR TITLE
fixes version comparison bug

### DIFF
--- a/files/default/handlers/windows_reboot_handler.rb
+++ b/files/default/handlers/windows_reboot_handler.rb
@@ -52,7 +52,7 @@ class WindowsRebootHandler < Chef::Handler
     node.run_state[:reboot_requested] == true
   end
 
-  if Chef::VERSION > '11.12'
+  if Gem::Version.new(Chef::VERSION) > Gem::Version.new('11.12')
     include Chef::DSL::RebootPending
   else
     # reboot cause WIN says so:


### PR DESCRIPTION
Commit 7471d87e6ca4e79eeffa67cb540669d912071852 introduced a change to use Chef DSL
if the chef-client version is greater than 11.12. However, since it compares strings
the results are unexpected (for example "11.6.2" is greater than "11.12").

This change compares Gem::Version objects instead of strings.

(Thanks Jon Lenzer :D )