### PR TITLE
Use dsl instead of manual resource instanciation

### DIFF
--- a/libraries/windows_helper.rb
+++ b/libraries/windows_helper.rb
@@ -79,11 +79,11 @@ module Windows
           uri = as_uri(source)
           cache_file_path = "#{Chef::Config[:file_cache_path]}/#{::File.basename(::URI.unescape(uri.path))}"
           Chef::Log.debug("Caching a copy of file #{source} at #{cache_file_path}")
-          r = Chef::Resource::RemoteFile.new(cache_file_path, run_context)
-          r.source(source)
-          r.backup(false)
-          r.checksum(checksum) if checksum
-          r.run_action(:create)
+          remote_file cache_file_path do
+            source source
+            backup false
+            checksum checksum unless checksum.nil?
+          end.run_action(:create)
         else
           cache_file_path = source
         end

--- a/providers/batch.rb
+++ b/providers/batch.rb
@@ -32,15 +32,14 @@ action :run do
     # follow CHEF-2357 for more
     cwd = @new_resource.cwd ? "cd \"#{@new_resource.cwd}\" & " : ''
 
-    r = Chef::Resource::Execute.new(@new_resource.name, run_context)
-    r.user(@new_resource.user)
-    r.group(@new_resource.group)
-    r.command("#{cwd}call \"#{script_file.path}\" #{@new_resource.flags}")
-    r.creates(@new_resource.creates)
-    r.returns(@new_resource.returns)
-    r.run_action(:run)
-
-    @new_resource.updated_by_last_action(r.updated_by_last_action?)
+    execute @new_resource.name do
+      action  :run
+      command "#{cwd}call \"#{script_file.path}\" #{@new_resource.flags}"
+      user    @new_resource.user unless @new_resource.user.nil?
+      group   @new_resource.group unless @new_resource.group.nil?
+      creates @new_resource.creates unless @new_resource.creates.nil?
+      returns @new_resource.returns unless @new_resource.returns.nil?
+    end
   ensure
     unlink_script_file
   end

--- a/providers/font.rb
+++ b/providers/font.rb
@@ -37,15 +37,17 @@ def font_exists?
 end
 
 def get_cookbook_font
-  r = Chef::Resource::CookbookFile.new(@new_resource.file, run_context)
-  r.path(win_friendly_path(::File.join(ENV['TEMP'], @new_resource.file)))
-  r.cookbook(cookbook_name.to_s)
-  r.run_action(:create)
+  cookbook_file @new_resource.file do
+    action    :create
+    cookbook  cookbook_name.to_s unless cookbook_name.nil?
+    path      win_friendly_path(::File.join(ENV['TEMP'], @new_resource.file))
+  end
 end
 
 def del_cookbook_font
-  r = Chef::Resource::File.new(::File.join(ENV['TEMP'], @new_resource.file), run_context)
-  r.run_action(:delete)
+  file ::File.join(ENV['TEMP'], @new_resource.file) do
+    action :delete
+  end
 end
 
 def install_font


### PR DESCRIPTION
Some providers and libraries are manually instanciating resources.
This is not really clean, and bypass many steps of the resource
initialization - setting cookbook name for instance.

I use the DSL and manually call `run_action` when it's required.

cc: @aboten