### PR TITLE
Create feature_cached.rb

### DIFF
--- a/providers/feature_cached.rb
+++ b/providers/feature_cached.rb
@@ -1,0 +1,80 @@
+#
+# Author:: Matthew Churcher (<Matthew.Churcher@newvoicemedia.com>)
+# Heavily based on feature_dism.rb by Seth Chisamore (<schisamo@chef.io>)
+# Cookbook Name:: windows
+# Provider:: feature_cached
+#
+# Copyright:: 2016, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include Chef::Provider::WindowsFeature::Base
+include Chef::Mixin::ShellOut
+include Windows::Helper
+
+def install_feature(_name)
+  addsource = @new_resource.source ? "/LimitAccess /Source:\"#{@new_resource.source}\"" : ''
+  addall = @new_resource.all ? '/All' : ''
+  shell_out!("#{dism} /online /enable-feature /featurename:#{@new_resource.feature_name} /norestart #{addsource} #{addall}", returns: [0, 42, 127, 3010])
+  clear_cache
+end
+
+def remove_feature(_name)
+  shell_out!("#{dism} /online /disable-feature /featurename:#{@new_resource.feature_name} /norestart", returns: [0, 42, 127, 3010])
+  clear_cache
+end
+
+def delete_feature(_name)
+  if win_version.major_version >= 6 && win_version.minor_version >= 2
+    shell_out!("#{dism} /online /disable-feature /featurename:#{@new_resource.feature_name} /Remove /norestart", returns: [0, 42, 127, 3010])
+  else
+    fail Chef::Exceptions::UnsupportedAction, "#{self} :delete action not support on #{win_version.sku}"
+  end
+  clear_cache
+end
+
+def installed?
+  @installed ||= begin
+    feature_list = get_feature_list
+    feature_list.stderr.empty? && (feature_list.stdout =~ /^Feature Name : #{@new_resource.feature_name}.?$\n^State : Enabled.?$/i)
+  end
+end
+
+def available?
+  @available ||= begin
+    feature_list = get_feature_list
+    feature_list.stderr.empty? && (feature_list.stdout !~ /^Feature Name : #{@new_resource.feature_name}.?$\n^State : .* with payload removed.?$/i)
+  end
+end
+
+private
+
+# account for File System Redirector
+# http://msdn.microsoft.com/en-us/library/aa384187(v=vs.85).aspx
+def dism
+  @dism ||= begin
+    locate_sysnative_cmd('dism.exe')
+  end
+end
+
+@@feature_list = nil
+def get_feature_list
+  if @@feature_list.nil?
+    @@feature_list = shell_out("#{dism} /online /Get-Features", returns: [0, 42, 127])
+  end
+end
+
+def clear_cache
+  @@feature_list = nil
+end


### PR DESCRIPTION
This is a cached version of feature_dism. Dism is ran once and a copy is stored in memory and reused for the life time of chef-client. As such it is an order of magnitude quick when checking multiple features
The cache is cleared if pages are installed or removed via this same provisioner.

For now to use set node.default['windows']['feature_provider'] = 'cached'.
Perhaps once it's proven it can be added to feature.rb as a normal option.

I've tested this with the provided test kitchen resources as well as with our own cookbooks.