### PR TITLE
Adding a vagrant user where needed in case we want to run this on AWS

### DIFF
--- a/test/cookbooks/minimal/recipes/tasks.rb
+++ b/test/cookbooks/minimal/recipes/tasks.rb
@@ -59,6 +59,10 @@ windows_task 'delete task delete_me' do
   action :delete
 end
 
+user 'vagrant' do
+  password 'vagrant'
+end
+
 windows_task 'task_for_system' do
   command 'dir'
   run_level :highest


### PR DESCRIPTION
With chef-acceptance we want to run this recipe on an AWS node, but the vagrant user doesn't exist there.  What do you think of this change @smurawski @mwrock ?  Or we could do a custom user like the [http_acl](https://github.com/chef-cookbooks/windows/blob/master/test/cookbooks/minimal/recipes/http_acl.rb) recipe uses