### PR TITLE
Add kitchen verify to Appveyor run

### DIFF
--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -1,0 +1,48 @@
+---
+driver:
+  name: proxy
+  host: localhost
+  reset_command: "exit 0"
+  port: 5985
+  username: <%= ENV["machine_user"] %>
+  password: <%= ENV["machine_pass"] %>
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: windows-2012R2
+
+verifier:
+  name: pester
+
+suites:
+  - name: tasks
+    run_list:
+      - recipe[windows::default]
+      - recipe[minimal::tasks]
+  - name: path
+    run_list:
+      - recipe[windows::default]
+      - recipe[minimal::path]
+  - name: certificate
+    run_list:
+      - recipe[windows::default]
+      - recipe[minimal::certificate]
+  - name: package
+    run_list:
+      - recipe[windows::default]
+      - recipe[minimal::package]
+  - name: feature
+    run_list:
+      - recipe[windows::default]
+      - recipe[minimal::feature]
+  - name: http_acl
+    run_list:
+      - recipe[windows::default]
+      - recipe[minimal::http_acl]
+
+  - name: font
+    run_list:
+      - recipe[windows::default]
+      - recipe[minimal::font]

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :unit do
 end
 
 group :kitchen_common do
-  gem 'test-kitchen', '~> 1.4'
+  gem 'test-kitchen', '~> 1.6'
 end
 
 group :kitchen_vagrant do
@@ -34,6 +34,6 @@ group :kitchen_cloud do
 end
 
 group :development do
-  gem 'winrm-transport'
+  gem 'winrm-fs', '~> 0.3'
   gem 'stove'
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,8 @@
+environment:
+  machine_user: vagrant
+  machine_pass: vagrant
+  KITCHEN_YAML: .kitchen.appveyor.yml
+
 branches:
   only:
     - master
@@ -8,8 +13,6 @@ skip_tags: true
 #faster cloning
 clone_depth: 1
 
-build: off
-
 # Install the latest nightly of ChefDK
 install:
   - ps: iex (irm https://omnitruck.chef.io/install.ps1); Install-Project -Project chefdk -channel current 
@@ -18,11 +21,21 @@ install:
   - ps: c:\opscode\chefdk\bin\chef.bat shell-init powershell | iex; cmd /c c:\opscode\chefdk\bin\chef.bat --version
   - c:\opscode\chefdk\bin\chef.bat exec ruby --version
   - c:\opscode\chefdk\bin\chef.bat gem install chef-sugar
+  - ps: secedit /export /cfg $env:temp/export.cfg
+  - ps: ((get-content $env:temp/export.cfg) -replace ('PasswordComplexity = 1', 'PasswordComplexity = 0')) | Out-File $env:temp/export.cfg
+  - ps: ((get-content $env:temp/export.cfg) -replace ('MinimumPasswordLength = 8', 'MinimumPasswordLength = 0')) | Out-File $env:temp/export.cfg
+  - ps: secedit /configure /db $env:windir/security/new.sdb /cfg $env:temp/export.cfg /areas SECURITYPOLICY
+  - ps: net user /add $env:machine_user $env:machine_pass
+  - ps: net localgroup administrators $env:machine_user /add
+
+build_script:
+  - bundle install || bundle install || bundle install
 
 test_script:
   - c:\opscode\chefdk\bin\chef.bat exec rubocop --version
   - c:\opscode\chefdk\bin\chef.bat exec foodcritic --version
   - c:\opscode\chefdk\bin\chef.bat exec rake style
   - c:\opscode\chefdk\bin\chef.bat exec rake spec
+  - c:\opscode\chefdk\embedded\bin\bundle.bat exec kitchen verify
 
 deploy: off


### PR DESCRIPTION
This runs all kitchen tests in appveyor. Should be fairly fast since it just uses the instance we already have. The motivation here is better feedback to contributors and less time in triage/testing.