### PR TITLE
bump and pin rubocop and fix broken cop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ end
 
 group :lint do
   gem 'foodcritic', '~> 6.0'
-  gem 'rubocop', '~> 0.34'
+  gem 'rubocop', '~> 0.37.2'
 end
 
 group :unit do

--- a/providers/task.rb
+++ b/providers/task.rb
@@ -157,7 +157,7 @@ def load_current_resource
   @current_resource.task_name(pathed_task_name)
   task_hash = load_task_hash(pathed_task_name)
 
-  if task_hash[:TaskName] == pathed_task_name
+  if task_hash.respond_to?(:[]) && task_hash[:TaskName] == pathed_task_name
     @current_resource.exists = true
     @current_resource.status = :running if task_hash[:Status] == 'Running'
     if task_hash[:ScheduledTaskState] == 'Enabled'
@@ -166,7 +166,7 @@ def load_current_resource
     @current_resource.cwd(task_hash[:StartIn]) unless task_hash[:StartIn] == 'N/A'
     @current_resource.command(task_hash[:TaskToRun])
     @current_resource.user(task_hash[:RunAsUser])
-  end if task_hash.respond_to? :[]
+  end
 end
 
 private


### PR DESCRIPTION
PRs are starting to break on rubocop 0.39.2. This fixes violations and pins to that.