### PR TITLE
take bundler out of the appveyor build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :unit do
 end
 
 group :kitchen_common do
-  gem 'test-kitchen', '~> 1.6'
+  gem 'test-kitchen', '~> 1.7'
 end
 
 group :kitchen_vagrant do
@@ -34,6 +34,6 @@ group :kitchen_cloud do
 end
 
 group :development do
-  gem 'winrm-fs', '~> 0.3'
+  gem 'winrm-fs', '~> 0.4.2'
   gem 'stove'
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,9 +18,9 @@ install:
   - ps: iex (irm https://omnitruck.chef.io/install.ps1); Install-Project -Project chefdk -channel current 
   - ps: 'Get-CimInstance win32_operatingsystem -Property Caption, OSArchitecture, Version | fl Caption, OSArchitecture, Version'
   - ps: $PSVersionTable
-  - ps: c:\opscode\chefdk\bin\chef.bat shell-init powershell | iex; cmd /c c:\opscode\chefdk\bin\chef.bat --version
   - c:\opscode\chefdk\bin\chef.bat exec ruby --version
   - c:\opscode\chefdk\bin\chef.bat gem install chef-sugar
+  - c:\opscode\chefdk\bin\chef.bat gem install kitchen-pester
   - ps: secedit /export /cfg $env:temp/export.cfg
   - ps: ((get-content $env:temp/export.cfg) -replace ('PasswordComplexity = 1', 'PasswordComplexity = 0')) | Out-File $env:temp/export.cfg
   - ps: ((get-content $env:temp/export.cfg) -replace ('MinimumPasswordLength = 8', 'MinimumPasswordLength = 0')) | Out-File $env:temp/export.cfg
@@ -29,13 +29,13 @@ install:
   - ps: net localgroup administrators $env:machine_user /add
 
 build_script:
-  - bundle install || bundle install || bundle install
+  - ps: c:\opscode\chefdk\bin\chef.bat shell-init powershell | iex; cmd /c c:\opscode\chefdk\bin\chef.bat --version
 
 test_script:
   - c:\opscode\chefdk\bin\chef.bat exec rubocop --version
   - c:\opscode\chefdk\bin\chef.bat exec foodcritic --version
   - c:\opscode\chefdk\bin\chef.bat exec rake style
   - c:\opscode\chefdk\bin\chef.bat exec rake spec
-  - c:\opscode\chefdk\embedded\bin\bundle.bat exec kitchen verify
+  - c:\opscode\chefdk\bin\chef.bat exec kitchen verify
 
 deploy: off


### PR DESCRIPTION
Our appveyor builds are currently breaking with gem conflicts between stuff in the bundle and the bin stubs from chefdk (see https://ci.appveyor.com/project/ChefWindowsCookbooks/windows/build/1.0.57).

This uses the chefdk exclusively and does not run bundler.