### PR TITLE
escape command quotes when passing to schtsks

### DIFF
--- a/providers/task.rb
+++ b/providers/task.rb
@@ -171,16 +171,18 @@ end
 
 private
 
+# rubocop:disable Style/StringLiteralsInInterpolation
 def run_schtasks(task_action, options = {})
   cmd = "schtasks /#{task_action} /TN \"#{@new_resource.task_name}\" "
   options.keys.each do |option|
     cmd += "/#{option} "
-    cmd += "\"#{options[option]}\" " unless options[option] == ''
+    cmd += "\"#{options[option].to_s.gsub('"', "\\\"")}\" " unless options[option] == ''
   end
   Chef::Log.debug('running: ')
   Chef::Log.debug("    #{cmd}")
   shell_out!(cmd, returns: [0])
 end
+# rubocop:enable Style/StringLiteralsInInterpolation
 
 def task_need_update?
   # gsub needed as schtasks converts single quotes to double quotes on creation

--- a/test/cookbooks/minimal/recipes/path.rb
+++ b/test/cookbooks/minimal/recipes/path.rb
@@ -20,3 +20,9 @@ windows_task 'testpath' do
   action [:create, :run]
   command 'powershell.exe -command $env:path > c:\\external_paths.txt'
 end
+
+ruby_block 'wait for task' do
+  block do
+    sleep 2
+  end
+end


### PR DESCRIPTION
Because the task provider does not escape quotes, consumers have to escape their own quotes. This not only makes the consuming experience awkward, but it can result in corrupted idempotency of the task resource. Agreat example is the `chef-client` cookbook's task recipe. It constructs the command as:
```
command "cmd /c \\\"#{node['chef_client']['ruby_bin']} #{node['chef_client']['bin']} \
  -L #{File.join(node['chef_client']['log_dir'], 'client.log')} \
  -c #{File.join(node['chef_client']['conf_dir'], 'client.rb')} -s #{node['chef_client']['splay']} > NUL 2>&1\\\""
```
because it is doing its own escaping, the idempotent check of the task provider `task_need_update?` results in an unequal command string and therefore the chef-client task recipe will converge every time.