### PR TITLE
  Add enable_windows_task ChefSpec matcher 

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ expect(chef_run).to install_windows_package('Node.js').with(
 * delete_windows_feature
 * create_windows_task
 * disable_windows_task
+* enable_windows_task
 * delete_windows_task
 * run_windows_task
 * change_windows_task

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -284,6 +284,31 @@ if defined?(ChefSpec)
 
   #
   # Assert that a +windows_task+ resource exists in the Chef run with the
+  # action +:enable+. Given a Chef Recipe that creates "mytask" as a
+  # +windows_task+:
+  #
+  #     windows_task 'mytask' do
+  #       action :enable
+  #     end
+  #
+  # The Examples section demonstrates the different ways to test a
+  # +windows_task+ resource with ChefSpec.
+  #
+  # @example Assert that a +windows_task+ was enabled
+  #   expect(chef_run).to enable_windows_task('mytask')
+  #
+  #
+  # @param [String, Regex] resource_name
+  #   the name of the resource to match
+  #
+  # @return [ChefSpec::Matchers::ResourceMatcher]
+  #
+  def enable_windows_task(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:windows_task, :enable, resource_name)
+  end
+
+  #
+  # Assert that a +windows_task+ resource exists in the Chef run with the
   # action +:delete+. Given a Chef Recipe that deletes "mytask" as a
   # +windows_task+:
   #


### PR DESCRIPTION
### Description

Adds an enable_windows_task matcher, allowing it to be used in ChefSpec tests.

### Issues Resolved

#367 

### Check List
- [ N/A ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ N/A ] New functionality includes testing
- [ Yes ] New functionality has been documented in the README if applicable
- [ N/A (Obvious Fix) ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


Fixes issue #367
Obvious fix