### PR TITLE
Restore Windows 2008 support for windows_feature

### DIFF
--- a/providers/feature_powershell.rb
+++ b/providers/feature_powershell.rb
@@ -9,13 +9,21 @@ include Chef::Provider::WindowsFeature::Base
 include Chef::Mixin::PowershellOut
 include Windows::Helper
 
+def install_feature_cmdlet
+  node['os_version'] < 6.2 ? 'Add-WindowsFeature' : 'Install-WindowsFeature'
+end
+
+def remove_feature_cmdlet
+  node['os_version'] < 6.2 ? 'Remove-WindowsFeature' : 'Uninstall-WindowsFeature'
+end
+
 def install_feature(_name)
-  cmd = powershell_out!("Install-WindowsFeature #{@new_resource.feature_name}")
+  cmd = powershell_out!("#{install_feature_cmdlet} #{@new_resource.feature_name}")
   Chef::Log.info(cmd.stdout)
 end
 
 def remove_feature(_name)
-  cmd = powershell_out!("Uninstall-WindowsFeature #{@new_resource.feature_name}")
+  cmd = powershell_out!("#{remove_feature_cmdlet} #{@new_resource.feature_name}")
   Chef::Log.info(cmd.stdout)
 end
 

--- a/test/cookbooks/minimal/recipes/package.rb
+++ b/test/cookbooks/minimal/recipes/package.rb
@@ -1,4 +1,4 @@
 windows_package 'Mercurial 3.6.1 (64-bit)' do
-  source 'http://mercurial.selenic.com/release/windows/Mercurial-3.6.1-x64.exe'
+  source 'https://www.mercurial-scm.org/release/windows/Mercurial-3.6.1-x64.exe'
   action :install
 end


### PR DESCRIPTION
### Description

Fixes Windows 2008 compatibility for the `windows_feature` resource.

### Issues Resolved

`windows_feature` at the moment breaks as `Install-WindowsFeature` does not exist in Windows 2008, 

### Check List

- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD