### PR TITLE
fixing powershell provider for windows 2008 (and 2k8r2)

### DIFF
--- a/providers/feature_powershell.rb
+++ b/providers/feature_powershell.rb
@@ -10,7 +10,7 @@ include Chef::Mixin::PowershellOut
 include Windows::Helper
 
 def install_feature_cmdlet
-  node['os_version'].to_f < 6.2 ? 'Add-WindowsFeature' : 'Install-WindowsFeature'
+  node['os_version'].to_f < 6.2 ? 'Import-Module ServerManager;Add-WindowsFeature' : 'Install-WindowsFeature'
 end
 
 def remove_feature_cmdlet


### PR DESCRIPTION
### Description

Windows 2008/r2 do not load system modules by default, so w/o `ImportSystemModueles` or `import-module servermanager` `add-windowsfeature` in powershell provider will not be found.

### Issues Resolved

https://github.com/chef-cookbooks/windows/issues/382 
&
https://getchef.zendesk.com/agent/tickets/11133


### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


