### PR TITLE
Add TrustedPublisher as a valid cert store_name

### DIFF
--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -24,5 +24,5 @@ default_action :create
 attribute :source, kind_of: String, name_attribute: true, required: true
 attribute :pfx_password, kind_of: String
 attribute :private_key_acl, kind_of: Array
-attribute :store_name, kind_of: String, default: 'MY', regex: /^(?:MY|CA|ROOT)$/
+attribute :store_name, kind_of: String, default: 'MY', regex: /^(?:MY|CA|ROOT|TrustedPublisher)$/
 attribute :user_store, kind_of: [TrueClass, FalseClass], default: false


### PR DESCRIPTION
### Description

Ability to use windows_certificate's to the TrustedPublisher store.
### Issues Resolved

#384

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

There are quite a few valid store_names:

```
> dir Cert:\LocalMachine
Name : SmartCardRoot
Name : TrustedPublisher
Name : Root
Name : Trust
Name : Remote Desktop
Name : AuthRoot
Name : CA
Name : Disallowed
Name : TrustedPeople
Name : My
Name : TrustedDevices
Name : ClientAuthIssuer
```