### PR TITLE
Add missing windows_font matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,6 +838,7 @@ expect(chef_run).to install_windows_package('Node.js').with(
 * request_windows_reboot
 * cancel_windows_reboot
 * create_windows_shortcut
+* install_windows_font
 
 
 Usage

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -19,6 +19,7 @@ if defined?(ChefSpec)
   define_method.call :windows_printer
   define_method.call :windows_printer_port
   define_method.call :windows_reboot
+  define_method.call :windows_font
 
   #
   # Assert that a +windows_certificate+ resource exists in the Chef run with the
@@ -577,4 +578,7 @@ if defined?(ChefSpec)
     ChefSpec::Matchers::ResourceMatcher.new(:windows_reboot, :cancel, resource_name)
   end
 
+  def install_windows_font(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:windows_font, :install, resource_name)
+  end
 end


### PR DESCRIPTION
### Description

The `windows_font` resource was missing it's chefspec matcher, making it difficult to unit test cookbooks that use it.

### Issues Resolved

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


