### PR TITLE
Don't use the package provider on Chef 12.6+

### DIFF
--- a/libraries/windows_package.rb
+++ b/libraries/windows_package.rb
@@ -224,7 +224,7 @@ class Chef
                     end
 
         Chef::Log.warn <<-EOF
-Please use the package resource available in Chef Client 12.6.
+Please use the package resource available in Chef Client 12.6+.
 windows_package will be removed in the next major version release
 of the Windows cookbook.
 EOF
@@ -233,17 +233,10 @@ EOF
   end
 end
 
-if Gem::Version.new(Chef::VERSION) < Gem::Version.new('12')
-  # this wires up the cookbook version of the windows_package resource as Chef::Resource::WindowsPackage,
-  # which is kinda hella janky
-  Chef::Resource.send(:remove_const, :WindowsPackage) if defined? Chef::Resource::WindowsPackage
-  Chef::Resource.const_set('WindowsPackage', Chef::Resource::WindowsCookbookPackage)
-else
-  if Chef.respond_to?(:set_resource_priority_array)
-    # this wires up the dynamic resource resolver to favor the cookbook version of windows_package over
-    # the internal version (but the internal Chef::Resource::WindowsPackage is still the internal version
-    # and a wrapper cookbook can override this e.g. for users that want to use the windows cookbook but
-    # want the internal windows_package resource)
-    Chef.set_resource_priority_array(:windows_package, [Chef::Resource::WindowsCookbookPackage], platform: 'windows')
-  end
+if Gem::Version.new(Chef::VERSION) < Gem::Version.new('12.6') && Chef.respond_to?(:set_resource_priority_array)
+  # this wires up the dynamic resource resolver to favor the cookbook version of windows_package over
+  # the internal version (but the internal Chef::Resource::WindowsPackage is still the internal version
+  # and a wrapper cookbook can override this e.g. for users that want to use the windows cookbook but
+  # want the internal windows_package resource)
+  Chef.set_resource_priority_array(:windows_package, [Chef::Resource::WindowsCookbookPackage], platform: 'windows')
 end


### PR DESCRIPTION
I need @lamont-granquist / @thommay to confirm this is going to work as I assume, but here's the thought:

Stop favoring the cookbook version of the provider on Chef 12.6+. On Chef 12.6+ just use the built in package provider. Remove the Chef 11 compatibility entirely and keep 12.0-12.5.1 working as they do now.