### PR TITLE
Update autorun to use built in registry resource

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,26 +17,28 @@ platforms:
   - name: windows-2012r2
     driver_config:
       box: chef/windows-server-2012r2-standard
-
 suites:
-  - name: tasks
+  - name: autorun
     run_list:
-      - recipe[test::tasks]
-  - name: path
-    run_list:
-      - recipe[test::path]
+      - recipe[test::autorun]
   - name: certificate
     run_list:
       - recipe[test::certificate]
-  - name: package
-    run_list:
-      - recipe[test::package]
   - name: feature
     run_list:
       - recipe[test::feature]
-  - name: http_acl
-    run_list:
-      - recipe[test::http_acl]
   - name: font
     run_list:
       - recipe[test::font]
+  - name: http_acl
+    run_list:
+      - recipe[test::http_acl]
+  - name: package
+    run_list:
+      - recipe[test::package]
+  - name: path
+    run_list:
+      - recipe[test::path]
+  - name: tasks
+    run_list:
+      - recipe[test::tasks]

--- a/providers/auto_run.rb
+++ b/providers/auto_run.rb
@@ -18,17 +18,30 @@
 # limitations under the License.
 #
 
+def whyrun_supported?
+  true
+end
+
 use_inline_resources
 
 action :create do
-  windows_registry 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run' do
-    values new_resource.name => "\"#{new_resource.program}\" #{new_resource.args}"
+  registry_key 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run' do
+    values [{
+      name: new_resource.name,
+      type: :string,
+      data: "\"#{new_resource.program}\" #{new_resource.args}"
+    }]
+    action :create
   end
 end
 
 action :remove do
-  windows_registry 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run' do
-    values new_resource.name => ''
-    action :remove
+  registry_key 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run' do
+    values [{
+      name: new_resource.name,
+      type: :string,
+      data: ''
+    }]
+    action :delete
   end
 end

--- a/test/cookbooks/test/recipes/autorun.rb
+++ b/test/cookbooks/test/recipes/autorun.rb
@@ -1,0 +1,11 @@
+include_recipe 'windows::default'
+
+windows_auto_run 'notepad' do
+  program 'C:/windows/system32/notepad.exe'
+  action  :create
+end
+
+windows_auto_run 'notepad' do
+  program 'C:/windows/system32/notepad.exe'
+  action  :remove
+end


### PR DESCRIPTION
We don't have a windows_registry provider anymore. Use the built in and add a test so we can make sure this keeps working

Signed-off-by: Tim Smith <tsmith@chef.io>