### PR TITLE
Registry helpers don't work properly on 64-bit Ruby on 64-bit Windows

### DIFF
--- a/libraries/registry_helper.rb
+++ b/libraries/registry_helper.rb
@@ -29,7 +29,8 @@ end
 
 module Windows
   module RegistryHelper
-    @@native_registry_constant = ENV['PROCESSOR_ARCHITEW6432'] == 'AMD64' ? 0x0100 : 0x0200
+    @@native_registry_constant = ENV['PROCESSOR_ARCHITECTURE'] == 'AMD64' ||
+      ENV['PROCESSOR_ARCHITEW6432'] == 'AMD64' ? 0x0100 : 0x0200
 
     def get_hive_name(path)
       Chef::Log.debug('Resolving registry shortcuts to full names')

--- a/libraries/registry_helper.rb
+++ b/libraries/registry_helper.rb
@@ -34,6 +34,7 @@ module Windows
       @@native_registry_constant = 0x0100
     else
       @@native_registry_constant = 0x0200
+    end
 
     def get_hive_name(path)
       Chef::Log.debug('Resolving registry shortcuts to full names')

--- a/libraries/registry_helper.rb
+++ b/libraries/registry_helper.rb
@@ -29,12 +29,12 @@ end
 
 module Windows
   module RegistryHelper
-    if ENV['PROCESSOR_ARCHITECTURE'] == 'AMD64' ||
-       ENV['PROCESSOR_ARCHITEW6432'] == 'AMD64'
-      @@native_registry_constant = 0x0100
-    else
-      @@native_registry_constant = 0x0200
-    end
+    @@native_registry_constant = if ENV['PROCESSOR_ARCHITECTURE'] == 'AMD64' ||
+                                    ENV['PROCESSOR_ARCHITEW6432'] == 'AMD64'
+                                   0x0100
+                                 else
+                                   0x0200
+                                 end
 
     def get_hive_name(path)
       Chef::Log.debug('Resolving registry shortcuts to full names')

--- a/libraries/registry_helper.rb
+++ b/libraries/registry_helper.rb
@@ -29,8 +29,11 @@ end
 
 module Windows
   module RegistryHelper
-    @@native_registry_constant = ENV['PROCESSOR_ARCHITECTURE'] == 'AMD64' ||
-      ENV['PROCESSOR_ARCHITEW6432'] == 'AMD64' ? 0x0100 : 0x0200
+    if ENV['PROCESSOR_ARCHITECTURE'] == 'AMD64' ||
+       ENV['PROCESSOR_ARCHITEW6432'] == 'AMD64'
+      @@native_registry_constant = 0x0100
+    else
+      @@native_registry_constant = 0x0200
 
     def get_hive_name(path)
       Chef::Log.debug('Resolving registry shortcuts to full names')


### PR DESCRIPTION
### Description

PROCESSOR_ARCHITEW6432 is null on 64-bit processes resulting in the registry helpers accessing the 32-bit registry nodes for keys in HKLM\SOFTWARE etc.

See http://blog.differentpla.net/blog/2013/03/10/processor-architew6432 for background

### Issues Resolved

#371

