### PR TITLE
AWS Opsworks 12.2 doesn't like chef_version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,4 +8,4 @@ version          '2.0.2'
 supports         'windows'
 source_url       'https://github.com/chef-cookbooks/windows'
 issues_url       'https://github.com/chef-cookbooks/windows/issues'
-chef_version     '>= 12.1'
+chef_version     '>= 12.1' if respond_to?(:chef_version)


### PR DESCRIPTION
### Description

Allows this cookbook to be used in Opsworks 12.2 (for windows)

### Check List
[+] All tests pass. 
[-] New functionality includes testing.
[+] New functionality has been documented in the README if applicable
[+] All commits have been signed for the Developer Certificate of Origin.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the 
    best of my knowledge, is covered under an appropriate open 
    source license and I have the right under that license to   
    submit that work with modifications, whether created in whole
    or in part by me, under the same open source license (unless
    I am permitted to submit under a different license), as 
    Indicated in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including 
    all personal information I submit with it, including my
    sign-off) is maintained indefinitely and may be redistributed
    consistent with this project or the open source license(s)
    involved.

Signed-off-by: Mark Hudson <hellohuddo@gmail.com>