### PR TITLE
Add deprecation dates. Align with Chef 13

### DIFF
--- a/libraries/powershell_out.rb
+++ b/libraries/powershell_out.rb
@@ -21,8 +21,11 @@ unless defined? Chef::Mixin::PowershellOut
         end
 
         def powershell_out(*command_args)
-          Chef::Log.warn 'The powershell_out library in the windows cookbook is deprecated.'
-          Chef::Log.warn 'Please upgrade to Chef 12.4.0 or later where it is built-in to core chef.'
+          Chef::Log.warn <<-EOF
+The powershell_out library in the windows cookbook is deprecated.
+Please upgrade to Chef 12.4.0 or later where it is built-in to core chef.
+This functionality will be removed from the next major version of the Windows cookbook on 4/2017.
+EOF
           script = command_args.first
           options = command_args.last.is_a?(Hash) ? command_args.last : nil
 

--- a/libraries/windows_package.rb
+++ b/libraries/windows_package.rb
@@ -226,7 +226,7 @@ class Chef
         Chef::Log.warn <<-EOF
 Please use the package resource available in Chef Client 12.6+.
 windows_package will be removed in the next major version release
-of the Windows cookbook.
+of the Windows cookbook on 4/2017.
 EOF
       end
     end


### PR DESCRIPTION
"next major version" is pretty vague. Let's give a date. Once Chef 13 comes out the compatibility with Chef < 12.6 in this cookbook is going to be removed. 