### PR TITLE
Allow to define http acl using SDDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,13 +235,21 @@ Sets the Access Control List for an http URL to grant non-admin accounts permiss
 #### Attribute Parameters
 
 - `url` - the name of the url to be created/deleted.
-- `user` - the name (domain\user) of the user or group to be granted permission to the URL. Mandatory for create. Only one user or group can be granted permission so this replaces any previously defined entry.
+- `sddl` - the DACL string configuring all permissions to URL. Mandatory for create if user is not provided. Can't be use with `user`.
+- `user` - the name (domain\user) of the user or group to be granted permission to the URL. Mandatory for create if sddl is not provided. Can't be use with `sddl`. Only one user or group can be granted permission so this replaces any previously defined entry.
 
 #### Examples
 
 ```ruby
 windows_http_acl 'http://+:50051/' do
     user 'pc\\fred'
+end
+```
+
+```ruby
+# Grant access to users "NT SERVICE\WinRM" and "NT SERVICE\Wecsvc" via sddl
+windows_http_acl 'http://+:5985/' do
+  sddl 'D:(A;;GX;;;S-1-5-80-569256582-2953403351-2909559716-1301513147-412116970)(A;;GX;;;S-1-5-80-4059739203-877974739-1245631912-527174227-2996563517)'
 end
 ```
 

--- a/providers/http_acl.rb
+++ b/providers/http_acl.rb
@@ -31,12 +31,15 @@ def whyrun_supported?
 end
 
 action :create do
-  raise 'No user property set' if @new_resource.user.nil? || @new_resource.user.empty?
+  raise '`user` xor `sddl` can\'t be used together' if @new_resource.user && @new_resource.sddl
+  raise 'When provided user property can\'t be empty' if @new_resource.user && @new_resource.user.empty?
+  raise 'When provided sddl property can\'t be empty' if @new_resource.sddl && @new_resource.sddl.empty?
 
   if @current_resource.exists
-    needsChange = (@current_resource.user.casecmp(@new_resource.user) != 0)
+    sddl_changed = (@current_resource.sddl.casecmp(@new_resource.sddl) != 0)
+    user_changed = (@current_resource.user.casecmp(@new_resource.user) != 0)
 
-    if needsChange
+    if sddl_changed || user_changed
       converge_by("Changing #{@current_resource.url}") do
         deleteAcl
         setAcl
@@ -72,20 +75,30 @@ end
 private
 
 def getCurrentAcl
-  cmd = shell_out!("#{@command} http show urlacl url=#{@current_resource.url}")
-  Chef::Log.debug "netsh reports: #{cmd.stdout}"
+  cmd_out = shell_out!("#{@command} http show urlacl url=#{@current_resource.url}").stdout
+  Chef::Log.debug "netsh reports: #{cmd_out}"
 
-  m = cmd.stdout.scan(/User:\s*(.+)/)
-  if m.empty?
-    @current_resource.exists = false
-  else
-    @current_resource.user(m[0][0].chomp)
+  if cmd_out.include? @current_resource.url
     @current_resource.exists = true
+
+    # Checks first for sddl, because it generates user(s)
+    sddl_match = cmd_out.match(/SDDL:\s*(?<sddl>.+)/)
+    if sddl_match
+      @current_resource.sddl(sddl_match['sddl'])
+    else
+      # if no sddl, tries to find a single user
+      user_match = cmd_out.match(/User:\s*(?<user>.+)/)
+      @current_resource.user user_match['user']
+    end
   end
 end
 
 def setAcl
-  shell_out!("#{@command} http add urlacl url=#{@new_resource.url} user=\"#{@new_resource.user}\"")
+  if @current_resource.sddl
+    shell_out!("#{@command} http add urlacl url=#{@new_resource.url} sddl=\"#{@new_resource.sddl}\"")
+  else
+    shell_out!("#{@command} http add urlacl url=#{@new_resource.url} user=\"#{@new_resource.user}\"")
+  end
 end
 
 def deleteAcl

--- a/resources/http_acl.rb
+++ b/resources/http_acl.rb
@@ -23,5 +23,6 @@ default_action :create
 
 attribute :url, kind_of: String, name_attribute: true, required: true
 attribute :user, kind_of: String
+attribute :sddl, kind_of: String
 
 attr_accessor :exists

--- a/test/cookbooks/minimal/recipes/http_acl.rb
+++ b/test/cookbooks/minimal/recipes/http_acl.rb
@@ -1,0 +1,17 @@
+windows_http_acl 'http://+:50051/' do
+  user 'pc\\fred'
+end
+
+windows_http_acl 'http://+:5986/' do
+  user 'NT SERVICE\Winrm'
+end
+
+# Grant access to users "NT SERVICE\WinRM" and "NT SERVICE\Wecsvc" via sddl
+windows_http_acl 'http://+:5985/' do
+  sddl 'D:(A;;GX;;;S-1-5-80-569256582-2953403351-2909559716-1301513147-412116970)' \
+       + '(A;;GX;;;S-1-5-80-4059739203-877974739-1245631912-527174227-2996563517)'
+end
+
+windows_http_acl 'http://+:50051/' do
+  action :delete
+end


### PR DESCRIPTION
Microsoft provides multiple ways to define url acl via users and SDDL.
SDDL (security descriptor definition language) allows complexe acls with
multiple users and groups.

**Cc:** @aboten