### PR TITLE
Make sure the ohai plugin is available when installing features

### DIFF
--- a/providers/feature_dism.rb
+++ b/providers/feature_dism.rb
@@ -50,6 +50,8 @@ end
 
 def installed?
   @installed ||= begin
+    install_ohai_plugin unless node['dism_features']
+
     # Compare against ohai plugin instead of costly dism run
     node['dism_features'].key?(@new_resource.feature_name) && node['dism_features'][@new_resource.feature_name] =~ /Enable/
   end
@@ -57,6 +59,8 @@ end
 
 def available?
   @available ||= begin
+    install_ohai_plugin unless node['dism_features']
+
     # Compare against ohai plugin instead of costly dism run
     node['dism_features'].key?(@new_resource.feature_name) && node['dism_features'][@new_resource.feature_name] !~ /with payload removed/
   end
@@ -66,6 +70,15 @@ def reload_ohai_features_plugin(take_action, feature_name)
   ohai "Reloading Dism_Features Plugin - Action #{take_action} of feature #{feature_name}" do
     action :reload
     plugin 'dism_features'
+  end
+end
+
+def install_ohai_plugin
+  Chef::Log.info("node['dism_features'] data missing. Installing the dism_features Ohai plugin")
+
+  ohai_plugin 'dism_features' do
+    compile_time true
+    cookbook 'windows'
   end
 end
 

--- a/test/cookbooks/test/recipes/feature.rb
+++ b/test/cookbooks/test/recipes/feature.rb
@@ -1,5 +1,3 @@
-include_recipe 'windows::default'
-
 node.default['windows']['feature_provider'] = 'dism'
 
 windows_feature 'TelnetClient' do


### PR DESCRIPTION
Having windows::default on your run_list should not be a requirement. Instead when we try to access the node data we should install the ohai plugin if the node data isn't there.