### PR TITLE
Deprecate the default recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,10 +818,6 @@ Place an explicit dependency on this cookbook (using depends in the cookbook's m
 depends 'windows'
 ```
 
-### default
-
-Convenience recipe that installs supporting gems for many of the resources/providers that ship with this cookbook.
-
 ## License & Authors
 
 - Author:: Seth Chisamore ([schisamo@chef.io](mailto:schisamo@chef.io))

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,25 +18,4 @@
 # limitations under the License.
 #
 
-# gems with precompiled binaries
-%w( win32-api win32-service ).each do |win_gem|
-  chef_gem win_gem do
-    options '--platform=mswin32'
-    action :install
-    compile_time false
-  end
-end
-
-# the rest
-%w( windows-api windows-pr win32-dir win32-event win32-mutex ).each do |win_gem|
-  chef_gem win_gem do
-    action :install
-    compile_time false
-  end
-end
-
-# Install Dism Feature Plugin
-
-ohai_plugin 'dism_features' do
-  compile_time true
-end
+Chef::Log.warn('The windows::default recipe has been deprecated. The gems previously installed in this recipe ship in the Chef MSI.')


### PR DESCRIPTION
The gems ship with the omnibus installs anyways. There’s no need for this and anyone that uses it is just slowing down their Chef runs. The ohai plugin is installed dynamically when needed now and I plan to get that into ohai as well in the future.

Signed-off-by: Tim Smith <tsmith@chef.io>