### PR TITLE
Allow passing array to windows_feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ servermanagercmd -query
 
 #### Properties
 
-- `feature_name` - name of the feature/role to install. The same feature may have different names depending on the provider used (ie DHCPServer vs DHCP; DNS-Server-Full-Role vs DNS).
+- `feature_name` - name of the feature/role(s) to install. The same feature may have different names depending on the provider used (ie DHCPServer vs DHCP; DNS-Server-Full-Role vs DNS).
 - `all` - Boolean. Optional. Default: false. DISM and Powershell providers only. Forces all dependencies to be installed.
 - `source` - String. Optional. DISM provider only. Uses local repository for feature install.
 
@@ -152,11 +152,11 @@ servermanagercmd -query
 
 - **Chef::Provider::WindowsFeature::DISM**: Uses Deployment Image Servicing and Management (DISM) to manage roles/features.
 - **Chef::Provider::WindowsFeature::ServerManagerCmd**: Uses Server Manager to manage roles/features.
-- **Chef::Provider::WindowsFeaturePowershell**: Uses Powershell to manage roles/features.
+- **Chef::Provider::WindowsFeature::Powershell**: Uses PowerShell to manage roles/features.
 
 #### Examples
 
-Enable the node as a DHCP Server
+Install the DHCP Server feature
 
 ```ruby
 windows_feature 'DHCPServer' do
@@ -164,15 +164,7 @@ windows_feature 'DHCPServer' do
 end
 ```
 
-Enable TFTP
-
-```ruby
-windows_feature 'TFTP' do
-  action :install
-end
-```
-
-Enable .Net 3.5.1 on Server 2012 using repository files on DVD and install all dependencies
+Install the .Net 3.5.1 feature on Server 2012 using repository files on DVD and install all dependencies
 
 ```ruby
 windows_feature "NetFx3" do
@@ -182,22 +174,29 @@ windows_feature "NetFx3" do
 end
 ```
 
-Disable Telnet client/server
+Remove Telnet Server and Client features
 
 ```ruby
-%w[TelnetServer TelnetClient].each do |feature|
-  windows_feature feature do
-    action :remove
-  end
+windows_feature ['TelnetServer', 'TelnetClient'] do
+  action :remove
 end
 ```
 
-Add SMTP Feature with powershell provider
+Add the SMTP Server feature using the PowerShell provider
 
 ```ruby
 windows_feature "smtp-server" do
   action :install
   all true
+  provider :windows_feature_powershell
+end
+```
+
+Install multiple features using one resource with the PowerShell provider
+
+```ruby
+windows_feature ['Web-Asp-Net45', 'Web-Net-Ext45'] do
+  action :install
   provider :windows_feature_powershell
 end
 ```

--- a/libraries/windows_helper.rb
+++ b/libraries/windows_helper.rb
@@ -124,6 +124,12 @@ module Windows
       end
     end
 
+    # Returns an array
+    def to_array(var)
+      var = var.is_a?(Array) ? var : [var]
+      var.reject(&:nil?)
+    end
+
     private
 
     def extract_installed_packages_from_key(hkey = ::Win32::Registry::HKEY_LOCAL_MACHINE, desired = ::Win32::Registry::Constants::KEY_READ)

--- a/providers/feature_dism.rb
+++ b/providers/feature_dism.rb
@@ -27,20 +27,20 @@ include Windows::Helper
 def install_feature(_name)
   addsource = @new_resource.source ? "/LimitAccess /Source:\"#{@new_resource.source}\"" : ''
   addall = @new_resource.all ? '/All' : ''
-  shell_out!("#{dism} /online /enable-feature /featurename:#{@new_resource.feature_name} /norestart #{addsource} #{addall}", returns: [0, 42, 127, 3010])
+  shell_out!("#{dism} /online /enable-feature #{to_array(@new_resource.feature_name).map { |feature| "/featurename:#{feature}" }.join(' ')} /norestart #{addsource} #{addall}", returns: [0, 42, 127, 3010])
   # Reload ohai data
   reload_ohai_features_plugin(@new_resource.action, @new_resource.feature_name)
 end
 
 def remove_feature(_name)
-  shell_out!("#{dism} /online /disable-feature /featurename:#{@new_resource.feature_name} /norestart", returns: [0, 42, 127, 3010])
+  shell_out!("#{dism} /online /disable-feature #{to_array(@new_resource.feature_name).map { |feature| "/featurename:#{feature}" }.join(' ')} /norestart", returns: [0, 42, 127, 3010])
   # Reload ohai data
   reload_ohai_features_plugin(@new_resource.action, @new_resource.feature_name)
 end
 
 def delete_feature(_name)
   if win_version.major_version >= 6 && win_version.minor_version >= 2
-    shell_out!("#{dism} /online /disable-feature /featurename:#{@new_resource.feature_name} /Remove /norestart", returns: [0, 42, 127, 3010])
+    shell_out!("#{dism} /online /disable-feature #{to_array(@new_resource.feature_name).map { |feature| "/featurename:#{feature}" }.join(' ')} /Remove /norestart", returns: [0, 42, 127, 3010])
     # Reload ohai data
     reload_ohai_features_plugin(@new_resource.action, @new_resource.feature_name)
   else

--- a/providers/feature_powershell.rb
+++ b/providers/feature_powershell.rb
@@ -20,30 +20,30 @@ end
 
 def install_feature(_name)
   addall = @new_resource.all ? '-IncludeAllSubFeature' : ''
-  cmd = powershell_out!("#{install_feature_cmdlet} #{@new_resource.feature_name} #{addall}")
+  cmd = powershell_out!("#{install_feature_cmdlet} #{to_array(@new_resource.feature_name).join(',')} #{addall}")
   Chef::Log.info(cmd.stdout)
 end
 
 def remove_feature(_name)
-  cmd = powershell_out!("#{remove_feature_cmdlet} #{@new_resource.feature_name}")
+  cmd = powershell_out!("#{remove_feature_cmdlet} #{to_array(@new_resource.feature_name).join(',')}")
   Chef::Log.info(cmd.stdout)
 end
 
 def delete_feature(_name)
-  cmd = powershell_out!("Uninstall-WindowsFeature #{@new_resource.feature_name} -Remove")
+  cmd = powershell_out!("Uninstall-WindowsFeature #{to_array(@new_resource.feature_name).join(',')} -Remove")
   Chef::Log.info(cmd.stdout)
 end
 
 def installed?
   @installed ||= begin
-    cmd = powershell_out("Get-WindowsFeature #{@new_resource.feature_name} | Select Installed | % { Write-Host $_.Installed }")
-    cmd.stderr.empty? && cmd.stdout =~ /True/i
+    cmd = powershell_out("(Get-WindowsFeature #{to_array(@new_resource.feature_name).join(',')} | ?{$_.InstallState -ne \'Installed\'}).count")
+    cmd.stderr.empty? && cmd.stdout.chomp.to_i.zero?
   end
 end
 
 def available?
   @available ||= begin
-    cmd = powershell_out("Get-WindowsFeature #{@new_resource.feature_name}")
-    cmd.stderr.empty? && cmd.stdout !~ /Removed/i
+    cmd = powershell_out("(Get-WindowsFeature #{to_array(@new_resource.feature_name).join(',')} | ?{$_.InstallState -ne \'Removed\'}).count")
+    cmd.stderr.empty? && cmd.stdout.chomp.to_i > 0
   end
 end

--- a/providers/feature_servermanagercmd.rb
+++ b/providers/feature_servermanagercmd.rb
@@ -38,11 +38,11 @@ def check_reboot(result, feature)
 end
 
 def install_feature(_name)
-  check_reboot(shell_out("#{servermanagercmd} -install #{@new_resource.feature_name}", returns: [0, 42, 127, 1003, 3010]), @new_resource.feature_name)
+  check_reboot(shell_out("#{servermanagercmd} -install #{to_array(@new_resource.feature_name).join(' ')}", returns: [0, 42, 127, 1003, 3010]), @new_resource.feature_name)
 end
 
 def remove_feature(_name)
-  check_reboot(shell_out("#{servermanagercmd} -remove #{@new_resource.feature_name}", returns: [0, 42, 127, 1003, 3010]), @new_resource.feature_name)
+  check_reboot(shell_out("#{servermanagercmd} -remove #{to_array(@new_resource.feature_name}).join(' '), returns: [0, 42, 127, 1003, 3010]), @new_resource.feature_name)
 end
 
 def installed?

--- a/resources/feature.rb
+++ b/resources/feature.rb
@@ -23,7 +23,7 @@ include Windows::Helper
 actions :install, :remove, :delete
 default_action :install
 
-attribute :feature_name, kind_of: String, name_attribute: true
+attribute :feature_name, kind_of: [Array, String], name_attribute: true
 attribute :source, kind_of: String
 attribute :all, kind_of: [TrueClass, FalseClass], default: false
 

--- a/test/cookbooks/test/recipes/feature.rb
+++ b/test/cookbooks/test/recipes/feature.rb
@@ -9,8 +9,13 @@ windows_feature 'TFTP-Client' do
   provider :windows_feature_powershell
 end
 
-windows_feature 'Web-Asp-Net45' do
+windows_feature 'Web-Ftp-Server' do
   action :install
   all    true
+  provider :windows_feature_powershell
+end
+
+windows_feature ['Web-Asp-Net45', 'Web-Net-Ext45'] do
+  action :install
   provider :windows_feature_powershell
 end

--- a/test/integration/feature/pester/minimal.package.Tests.ps1
+++ b/test/integration/feature/pester/minimal.package.Tests.ps1
@@ -3,16 +3,20 @@ $global:progressPreference = 'SilentlyContinue'
 describe 'test::feature' {
   context 'minimal_feature' {
 
-    it "feature TelnetClient was created"  {
+    it "feature TelnetClient installed using dism"  {
       Get-Command Telnet -ErrorAction SilentlyContinue | Should Not Be $Null
     }
 
-    it "feature TFTP Client was created"  {
+    it "feature TFTP Client installed using powershell"  {
       Get-Command tftp -ErrorAction SilentlyContinue | Should Not Be $Null
     }
 
-    it "feature ASP.NET 4.5 was created"  {
-      (Get-WindowsFeature -Name Web-Asp-Net45).Installed | Should Be $True
+    it "feature Web-Ftp-Server and sub features installed using powershell" {
+      (Get-WindowsFeature Web-Ftp-* | ?{$_.InstallState -eq "Installed"}).count | Should Be 3
+    }
+
+    it "feature Web-Asp-Net45 and Web-Net-Ext45 installed using powershell" {
+      (Get-WindowsFeature Web-Asp-Net45,Web-Net-Ext45 | ?{$_.InstallState -eq "Installed"}).count | Should Be 2
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>

### Description

This change allows installing multiple features/roles using a single resource/shell_out.

### Issues Resolved

I came across an instance where using `Add-WindowsFeature` would install features that had an install state of "PendingReboot".  I did not want to make `windows_feature` notify my `reboot` resource because I potentially could've had two reboots to install two features; but installing all required features in one go and then rebooting is more acceptable.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
