### PR TITLE
remove duplicate default_action

### DIFF
--- a/resources/shortcut.rb
+++ b/resources/shortcut.rb
@@ -21,7 +21,6 @@
 actions :create
 
 default_action :create
-default_action :create
 
 attribute :name, kind_of: String
 attribute :target, kind_of: String


### PR DESCRIPTION
### Description

Removes a duplicate `default_action`

### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
