### PR TITLE
Don’t define use_inline_resources twice in the feature LWRP

### DIFF
--- a/providers/task.rb
+++ b/providers/task.rb
@@ -18,8 +18,6 @@
 # limitations under the License.
 #
 
-use_inline_resources
-
 require 'chef/mixin/shell_out'
 require 'rexml/document'
 


### PR DESCRIPTION
Signed-off-by: Tim Smith <tsmith@chef.io>