### PR TITLE
Add back the DISM ohai plugin installation in the default recipe

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,4 +18,7 @@
 # limitations under the License.
 #
 
-Chef::Log.warn('The windows::default recipe has been deprecated. The gems previously installed in this recipe ship in the Chef MSI.')
+# Install Dism Feature Plugin
+ohai_plugin 'dism_features' do
+  compile_time true
+end


### PR DESCRIPTION
I removed this by accident when I removed all the gem installs. We need this still

Signed-off-by: Tim Smith <tsmith@chef.io>