### PR TITLE
CHANGELOG: add release date to v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file is used to list changes made in each version of the windows cookbook.
 
 - Fix `windows_share` to be fully idempotent.  Fixes #447
 
-## 3.0.0 (UNRELEASED!)
+## 3.0.0 (2017-03-15)
 
 **Warning** This release includes multiple breaking changes as we refactored all existing resources and resolved many longstanding bugs. We highly recommend exercising caution and fully testing this new version before rolling it out to a production environment.
 


### PR DESCRIPTION
### Description

As v3.0.0 was actualy released two days ago so fix release date in changelog.