### PR TITLE
Add support for windows_task resource to run on non-English editions of Windows

### DIFF
--- a/resources/task.rb
+++ b/resources/task.rb
@@ -25,6 +25,7 @@ require 'chef/mixin/shell_out'
 require 'rexml/document'
 
 include Chef::Mixin::ShellOut
+include Chef::Mixin::PowershellOut
 
 property :task_name, String, name_property: true, regex: [/\A[^\/\:\*\?\<\>\|]+\z/]
 property :command, String
@@ -56,8 +57,12 @@ property :enabled, [true, false], desired_state: true
 def load_task_hash(task_name)
   Chef::Log.debug 'Looking for existing tasks'
 
-  # we use shell_out here instead of shell_out! because a failure implies that the task does not exist
-  output = shell_out("schtasks /Query /FO LIST /V /TN \"#{task_name}\"").stdout
+  # we use powershell_out here instead of powershell_out! because a failure implies that the task does not exist
+  task_script = <<-EOH
+    [Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8
+    schtasks /Query /FO LIST /V /TN \"#{task_name}\"
+  EOH
+  output = powershell_out(task_script).stdout.force_encoding('UTF-8')
   if output.empty?
     task = false
   else


### PR DESCRIPTION
### Description

Add support for `windows_task` resource to run on non-English editions of Windows.

As for now, `windows_task` resource created on every converge on non-English version of Windows, for example, Russian edition.

This is because
```ruby
def task_need_update?
    # gsub needed as schtasks converts single quotes to double quotes on creation
    current_resource.command != new_resource.command.tr("'", '"') ||
      current_resource.user != new_resource.user
  end
```
always returns that task need to update because
```ruby
output = shell_out("schtasks /Query /FO LIST /V /TN \"#{task_name}\"").stdout
```
outputs in local codepage and therefore can not be parsed successfully.

Further discussion here https://github.com/chef/chef/pull/5886

### Fixes
https://github.com/chef-cookbooks/windows/issues/462

Signed-off-by: Anton Kvashenkin <anton.jugatsu@gmail.com>