### PR TITLE
Remove action_class.class_eval usage / require 12.7+

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,4 +9,4 @@ supports         'windows'
 depends          'ohai', '>= 4.0.0'
 source_url       'https://github.com/chef-cookbooks/windows'
 issues_url       'https://github.com/chef-cookbooks/windows/issues'
-chef_version     '>= 12.6' if respond_to?(:chef_version)
+chef_version     '>= 12.7' if respond_to?(:chef_version)

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -100,7 +100,7 @@ EOH
   end
 end
 
-action_class.class_eval do
+action_class do
   def cert_location
     @location ||= new_resource.user_store ? 'CurrentUser' : 'LocalMachine'
   end

--- a/resources/certificate_binding.rb
+++ b/resources/certificate_binding.rb
@@ -81,7 +81,7 @@ action :delete do
   end
 end
 
-action_class.class_eval do
+action_class do
   def netsh_command
     locate_sysnative_cmd('netsh.exe')
   end

--- a/resources/feature.rb
+++ b/resources/feature.rb
@@ -37,7 +37,7 @@ action :delete do
   run_default_provider :delete
 end
 
-action_class.class_eval do
+action_class do
   def locate_default_provider
     if new_resource.install_method
       new_resource.install_method

--- a/resources/feature_dism.rb
+++ b/resources/feature_dism.rb
@@ -59,7 +59,7 @@ action :delete do
   end
 end
 
-action_class.class_eval do
+action_class do
   def installed?
     @installed ||= begin
       install_ohai_plugin unless node['dism_features']

--- a/resources/feature_powershell.rb
+++ b/resources/feature_powershell.rb
@@ -29,7 +29,7 @@ action :delete do
   end
 end
 
-action_class.class_eval do
+action_class do
   def install_feature_cmdlet
     node['os_version'].to_f < 6.2 ? 'Import-Module ServerManager; Add-WindowsFeature' : 'Install-WindowsFeature'
   end

--- a/resources/feature_servermanagercmd.rb
+++ b/resources/feature_servermanagercmd.rb
@@ -47,7 +47,7 @@ end
 
 # Exit codes are listed at http://technet.microsoft.com/en-us/library/cc749128(v=ws.10).aspx
 
-action_class.class_eval do
+action_class do
   def check_reboot(result, feature)
     if result.exitstatus == 3010 # successful, but needs reboot
       node.run_state['reboot_requested'] = true

--- a/resources/font.rb
+++ b/resources/font.rb
@@ -34,7 +34,7 @@ action :install do
   end
 end
 
-action_class.class_eval do
+action_class do
   def retrieve_cookbook_font
     font_file = new_resource.name
     if new_resource.source

--- a/resources/http_acl.rb
+++ b/resources/http_acl.rb
@@ -91,7 +91,7 @@ action :delete do
   end
 end
 
-action_class.class_eval do
+action_class do
   def netsh_command
     locate_sysnative_cmd('netsh.exe')
   end

--- a/resources/pagefile.rb
+++ b/resources/pagefile.rb
@@ -62,7 +62,7 @@ action :delete do
   delete(pagefile) if exists?(pagefile)
 end
 
-action_class.class_eval do
+action_class do
   def validate_name
     return if /^.:.*.sys/ =~ new_resource.name
     raise "#{new_resource.name} does not match the format DRIVE:\\path\\file.sys for pagefiles. Example: C:\\pagefile.sys"

--- a/resources/printer.rb
+++ b/resources/printer.rb
@@ -66,7 +66,7 @@ action :delete do
   end
 end
 
-action_class.class_eval do
+action_class do
   def create_printer
     # Create the printer port first
     windows_printer_port new_resource.ipv4_address do

--- a/resources/printer_port.rb
+++ b/resources/printer_port.rb
@@ -67,7 +67,7 @@ action :delete do
   end
 end
 
-action_class.class_eval do
+action_class do
   def create_printer_port
     port_name = new_resource.port_name || "IP_#{new_resource.ipv4_address}"
 

--- a/resources/share.rb
+++ b/resources/share.rb
@@ -128,7 +128,7 @@ def share_permissions(name)
   }
 end
 
-action_class.class_eval do
+action_class do
   def description_exists?(resource)
     !resource.description.nil?
   end

--- a/resources/task.rb
+++ b/resources/task.rb
@@ -221,7 +221,7 @@ action :disable do
   end
 end
 
-action_class.class_eval do
+action_class do
   # rubocop:disable Style/StringLiteralsInInterpolation
   def run_schtasks(task_action, options = {})
     cmd = "schtasks /#{task_action} /TN \"#{new_resource.task_name}\" "

--- a/resources/zipfile.rb
+++ b/resources/zipfile.rb
@@ -110,7 +110,7 @@ action :zip do
   end
 end
 
-action_class.class_eval do
+action_class do
   def ensure_rubyzip_gem_installed
     require 'zip'
   rescue LoadError


### PR DESCRIPTION
class_eval causes issues with later Chef 12 releases

Signed-off-by: Tim Smith <tsmith@chef.io>