### PR TITLE
windows_shortcut: update example to a version that is idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,16 +441,16 @@ Creates and modifies Windows shortcuts.
 
 #### Examples
 
-Add a shortcut all users desktop:
+Add a shortcut to all users desktop:
 
 ```ruby
 require 'win32ole'
 all_users_desktop = WIN32OLE.new("WScript.Shell").SpecialFolders("AllUsersDesktop")
 
 windows_shortcut "#{all_users_desktop}/Notepad.lnk" do
-  target "C:\\WINDOWS\\notepad.exe"
+  target "C:\\Windows\\notepad.exe"
   description "Launch Notepad"
-  iconlocation "C:\\windows\\notepad.exe, 0"
+  iconlocation "C:\\Windows\\notepad.exe,0"
 end
 ```
 


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

Doc fix: Fixes the example for the `windows_shortcut` resource to be idempotent. The previous example was not idempotent because the formatting of the retrieved values did not match the example properties.
