### PR TITLE
Adding autocrlf directive for correct line endings on Appveyor build node

### DIFF
--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -18,9 +18,6 @@ verifier:
   name: pester
 
 suites:
-  - name: tasks
-    run_list:
-      - recipe[test::tasks]
   - name: path
     run_list:
       - recipe[test::path]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,9 @@ skip_tags: true
 #faster cloning
 clone_depth: 1
 
+init:
+  - git config --global core.autocrlf true
+
 # Install the latest nightly of ChefDK
 install:
   - ps: iex (irm https://omnitruck.chef.io/install.ps1); Install-Project -Project chefdk -channel current


### PR DESCRIPTION
### Description

This change should ensure that the .rubocop.yml and other configuration files are delivered to the Appveyor build node with the correct line endings for the platform (i.e. CRLF on Windows)

### Issues Resolved

Cookstyle (via `delivery local all` previously failed on this step due to mismatched line endings)

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
