### PR TITLE
Revert "Require path in the share resource instead of raising if it's…

### DIFF
--- a/resources/share.rb
+++ b/resources/share.rb
@@ -20,7 +20,7 @@
 #
 
 property :share_name, String, name_property: true
-property :path, String, required: true
+property :path, String
 property :description, String, default: ''
 property :full_users, Array, default: []
 property :change_users, Array, default: []
@@ -36,6 +36,8 @@ ACCESS_CHANGE = 1_245_631
 ACCESS_READ = 1_179_817
 
 action :create do
+  raise 'No path property set' unless new_resource.path
+
   if different_path?
     unless current_resource.path.nil? || current_resource.path.empty?
       converge_by('Removing previous share') do


### PR DESCRIPTION
This PR reverts commit fc2691ff5b126a8412a6caea2a5c99b6051ea54f fixing #482 #490

### Description
fc2691ff5b126a8412a6caea2a5c99b6051ea54f changed the `windows_share` LWRP `path` property to `required`  instead of throwing an exception when its missing.

Despite the path being specified the chef-client run fails with 'path is required`. See #482 #490 and comments on the commit fc2691ff5b126a8412a6caea2a5c99b6051ea54f for details.

The root cause may lie in chef-client LWRP DSL, but requesting this commit to be reverted as this failure occurs with many recent chef-clients.

Signed-off-by: Richard Nixon <richard.nixon@btinternet.com>
