### PR TITLE
Adds the ability to define a timeout on windows_feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ get-windowsfeature
 - `feature_name` - name of the feature/role(s) to install. The same feature may have different names depending on the provider used (ie DHCPServer vs DHCP; DNS-Server-Full-Role vs DNS).
 - `all` - Boolean. Optional. Default: false. DISM and PowerShell providers only. For DISM this is the equivalent of specifying the /All switch to dism.exe, forcing all parent dependencies to be installed. With the PowerShell install method, the `-InstallAllSubFeatures` switch is applied. Note that these two methods may not produce identical results.
 - `management_tools` - Boolean. Optional. Default: false. PowerShell provider only. Includes the `-IncludeManagementTools` switch. Installs all applicable management tools of the roles, role services, or features specified by the feature name.
-- `source` - String. Optional. DISM provider only. Uses local repository for feature install.
+- `source` - String. Optional. DISM and PowerShell providers only. Uses local repository for feature install.
 - `timeout` - Integer. Optional. Default: 600. Specifies a timeout (in seconds) for feature install.
 - `install_method` - Symbol. Optional. If not supplied, Chef will determine which method to use (in the order of `:windows_feature_dism`, `:windows_feature_servercmd`, `:windows_feature_powershell`)
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ get-windowsfeature
 - `all` - Boolean. Optional. Default: false. DISM and PowerShell providers only. For DISM this is the equivalent of specifying the /All switch to dism.exe, forcing all parent dependencies to be installed. With the PowerShell install method, the `-InstallAllSubFeatures` switch is applied. Note that these two methods may not produce identical results.
 - `management_tools` - Boolean. Optional. Default: false. PowerShell provider only. Includes the `-IncludeManagementTools` switch. Installs all applicable management tools of the roles, role services, or features specified by the feature name.
 - `source` - String. Optional. DISM provider only. Uses local repository for feature install.
+- `timeout` - Integer. Optional. Default: 600. Specifies a timeout (in seconds) for feature install.
 - `install_method` - Symbol. Optional. If not supplied, Chef will determine which method to use (in the order of `:windows_feature_dism`, `:windows_feature_servercmd`, `:windows_feature_powershell`)
 
 #### Examples
@@ -207,13 +208,14 @@ windows_feature 'DHCPServer' do
 end
 ```
 
-Install the .Net 3.5.1 feature on Server 2012 using repository files on DVD and install all dependencies
+Install the .Net 3.5.1 feature on Server 2012 using repository files on DVD and install all dependencies with a timeout of 900 seconds
 
 ```ruby
 windows_feature "NetFx3" do
   action :install
   all true
   source "d:\sources\sxs"
+  timeout 900
 end
 ```
 

--- a/resources/feature.rb
+++ b/resources/feature.rb
@@ -70,7 +70,6 @@ action_class do
       windows_feature_servermanagercmd new_resource.name do
         action desired_action
         feature_name new_resource.feature_name
-        source new_resource.source if new_resource.source
         all new_resource.all
         timout new_resource.timeout
       end
@@ -81,7 +80,7 @@ action_class do
         source new_resource.source if new_resource.source
         all new_resource.all
         timout new_resource.timeout
-	management_tools new_resource.management_tools
+        management_tools new_resource.management_tools
       end
     end
   end

--- a/resources/feature.rb
+++ b/resources/feature.rb
@@ -23,6 +23,7 @@ property :source, String
 property :all, [true, false], default: false
 property :management_tools, [true, false], default: false
 property :install_method, Symbol, equal_to: [:windows_feature_dism, :windows_feature_powershell, :windows_feature_servermanagercmd]
+property :timeout, Integer, default: 600
 
 include Windows::Helper
 
@@ -63,6 +64,7 @@ action_class do
         feature_name new_resource.feature_name
         source new_resource.source if new_resource.source
         all new_resource.all
+        timout new_resource.timeout
       end
     when :windows_feature_servermanagercmd
       windows_feature_servermanagercmd new_resource.name do
@@ -70,6 +72,7 @@ action_class do
         feature_name new_resource.feature_name
         source new_resource.source if new_resource.source
         all new_resource.all
+        timout new_resource.timeout
       end
     when :windows_feature_powershell
       windows_feature_powershell new_resource.name do
@@ -77,7 +80,8 @@ action_class do
         feature_name new_resource.feature_name
         source new_resource.source if new_resource.source
         all new_resource.all
-        management_tools new_resource.management_tools
+        timout new_resource.timeout
+	management_tools new_resource.management_tools
       end
     end
   end

--- a/resources/feature_servermanagercmd.rb
+++ b/resources/feature_servermanagercmd.rb
@@ -19,7 +19,6 @@
 #
 
 property :feature_name, [Array, String], name_attribute: true
-property :source, String
 property :all, [true, false], default: false
 property :timeout, Integer, default: 600
 

--- a/resources/feature_servermanagercmd.rb
+++ b/resources/feature_servermanagercmd.rb
@@ -21,6 +21,7 @@
 property :feature_name, [Array, String], name_attribute: true
 property :source, String
 property :all, [true, false], default: false
+property :timeout, Integer, default: 600
 
 include Chef::Mixin::ShellOut
 include Windows::Helper
@@ -28,7 +29,7 @@ include Windows::Helper
 action :install do
   unless installed?
     converge_by("install Windows feature #{new_resource.feature_name}") do
-      check_reboot(shell_out("#{servermanagercmd} -install #{to_array(new_resource.feature_name).join(' ')}", returns: [0, 42, 127, 1003, 3010]), new_resource.feature_name)
+      check_reboot(shell_out("#{servermanagercmd} -install #{to_array(new_resource.feature_name).join(' ')}", returns: [0, 42, 127, 1003, 3010], timeout: new_resource.timeout), new_resource.feature_name)
     end
   end
 end
@@ -36,7 +37,7 @@ end
 action :remove do
   if installed?
     converge_by("removing Windows feature #{new_resource.feature_name}") do
-      check_reboot(shell_out("#{servermanagercmd} -remove #{to_array(new_resource.feature_name).join(' ')}", returns: [0, 42, 127, 1003, 3010]), new_resource.feature_name)
+      check_reboot(shell_out("#{servermanagercmd} -remove #{to_array(new_resource.feature_name).join(' ')}", returns: [0, 42, 127, 1003, 3010], timeout: new_resource.timeout), new_resource.feature_name)
     end
   end
 end
@@ -61,7 +62,7 @@ action_class do
 
   def installed?
     @installed ||= begin
-      cmd = shell_out("#{servermanagercmd} -query", returns: [0, 42, 127, 1003])
+      cmd = shell_out("#{servermanagercmd} -query", returns: [0, 42, 127, 1003], timeout: new_resource.timeout)
       cmd.stderr.empty? && (cmd.stdout =~ /^\s*?\[X\]\s.+?\s\[#{new_resource.feature_name}\]\s*$/i)
     end
   end


### PR DESCRIPTION
### Description

Adds the ability to define a timeout on windows_feature by adding a property to be passed to shell_out.
Removes the `source` property from the servermanagercmd provider as it does not support it.
Updates README to reflect `source` available for the Powershell provider as of #434 

### Issues Resolved

Fixes #370 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
