### PR TITLE
Adds management_tools property to windows_feature powershell provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ get-windowsfeature
 
 - `feature_name` - name of the feature/role(s) to install. The same feature may have different names depending on the provider used (ie DHCPServer vs DHCP; DNS-Server-Full-Role vs DNS).
 - `all` - Boolean. Optional. Default: false. DISM and PowerShell providers only. For DISM this is the equivalent of specifying the /All switch to dism.exe, forcing all parent dependencies to be installed. With the PowerShell install method, the `-InstallAllSubFeatures` switch is applied. Note that these two methods may not produce identical results.
+- `management_tools` - Boolean. Optional. Default: false. PowerShell provider only. Includes the `-IncludeManagementTools` switch. Installs all applicable management tools of the roles, role services, or features specified by the feature name.
 - `source` - String. Optional. DISM provider only. Uses local repository for feature install.
 - `install_method` - Symbol. Optional. If not supplied, Chef will determine which method to use (in the order of `:windows_feature_dism`, `:windows_feature_servercmd`, `:windows_feature_powershell`)
 
@@ -214,6 +215,16 @@ Install multiple features using one resource with the PowerShell provider
 ```ruby
 windows_feature ['Web-Asp-Net45', 'Web-Net-Ext45'] do
   action :install
+  install_method :windows_feature_powershell
+end
+```
+
+Install the Network Policy and Access Service feature, including the management tools. Which, for this example, will automatically install `RSAT-NPAS` as well.
+
+```ruby
+windows_feature 'NPAS' do
+  action :install
+  management_tools true
   install_method :windows_feature_powershell
 end
 ```

--- a/resources/feature.rb
+++ b/resources/feature.rb
@@ -21,6 +21,7 @@
 property :feature_name, [Array, String], name_property: true
 property :source, String
 property :all, [true, false], default: false
+property :management_tools, [true, false], default: false
 property :install_method, Symbol, equal_to: [:windows_feature_dism, :windows_feature_powershell, :windows_feature_servermanagercmd]
 
 include Windows::Helper
@@ -76,6 +77,7 @@ action_class do
         feature_name new_resource.feature_name
         source new_resource.source if new_resource.source
         all new_resource.all
+        management_tools new_resource.management_tools
       end
     end
   end

--- a/resources/feature_powershell.rb
+++ b/resources/feature_powershell.rb
@@ -7,6 +7,7 @@
 property :feature_name, [Array, String], name_attribute: true
 property :source, String
 property :all, [true, false], default: false
+property :management_tools, [true, false], default: false
 
 include Chef::Mixin::PowershellOut
 include Windows::Helper
@@ -59,10 +60,11 @@ action :install do
     converge_by("install Windows feature #{new_resource.feature_name}") do
       addsource = new_resource.source ? "-Source \"#{new_resource.source}\"" : ''
       addall = new_resource.all ? '-IncludeAllSubFeature' : ''
+      addmanagementtools = new_resource.management_tools ? '-IncludeManagementTools' : ''
       cmd = if node['os_version'].to_f < 6.2
               powershell_out!("#{install_feature_cmdlet} #{to_array(new_resource.feature_name).join(',')} #{addall}")
             else
-              powershell_out!("#{install_feature_cmdlet} #{to_array(new_resource.feature_name).join(',')} #{addsource} #{addall}")
+              powershell_out!("#{install_feature_cmdlet} #{to_array(new_resource.feature_name).join(',')} #{addsource} #{addall} #{addmanagementtools}")
             end
       Chef::Log.info(cmd.stdout)
     end

--- a/test/cookbooks/test/recipes/feature.rb
+++ b/test/cookbooks/test/recipes/feature.rb
@@ -27,3 +27,9 @@ windows_feature ['Web-Asp-Net45', 'Web-Net-Ext45'] do
   action :install
   install_method :windows_feature_powershell
 end
+
+windows_feature ['NPAS'] do
+  action :install
+  management_tools true
+  install_method :windows_feature_powershell
+end

--- a/test/integration/feature/pester/minimal.package.Tests.ps1
+++ b/test/integration/feature/pester/minimal.package.Tests.ps1
@@ -18,5 +18,9 @@ describe 'test::feature' {
     it "feature Web-Asp-Net45 and Web-Net-Ext45 installed using powershell" {
       (Get-WindowsFeature Web-Asp-Net45,Web-Net-Ext45 | ?{$_.InstallState -eq "Installed"}).count | Should Be 2
     }
+
+    it "feature NPAS and management tools installed using powershell" {
+      (Get-WindowsFeature NPAS,NPAS-Policy-Server,RSAT-NPAS | ?{$_.InstallState -eq "Installed"}).count | Should Be 3
+    }
   }
 }

--- a/test/integration/path/pester/minimal.path.Tests.ps1
+++ b/test/integration/path/pester/minimal.path.Tests.ps1
@@ -20,13 +20,13 @@ describe 'test::path' {
     }
 
     it 'Child processes and shellouts have an updated path' {
-      'c:\paths.txt' | should contain 'C:\\path_test_another_path'
-      'c:\paths.txt' | should contain 'C:\\path_test_path'
+      'c:\paths.txt' | should FileContentMatch 'C:\\path_test_another_path'
+      'c:\paths.txt' | should FileContentMatch 'C:\\path_test_path'
     }
 
     it 'Updates the path for new external processes' {
-      'c:\external_paths.txt' | should contain 'C:\\path_test_another_path'
-      'c:\external_paths.txt' | should contain 'C:\\path_test_path'
+      'c:\external_paths.txt' | should FileContentMatch 'C:\\path_test_another_path'
+      'c:\external_paths.txt' | should FileContentMatch 'C:\\path_test_path'
     }
   }
 }


### PR DESCRIPTION
### Description

Adds `management_tools` property to windows_feature usable by the powershell provider to set the `-IncludeManagementTools` switch on the cmdlet to install all applicable management tools of the roles, role services, or features specified by the feature name

### Issues Resolved

Fixes #468 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
