### PR TITLE
Allow fonts to be pulled from a remote location

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,12 +231,16 @@ Font files should be included in the cookbooks
 #### Properties
 
 - `name` - The file name of the font file name to install. The path defaults to the files/default directory of the cookbook you're calling windows_font from. Defaults to the resource name.
-- `source` - Set an alternate path to the font file.
+- `source` - Set an alternate path/URI to the font file.
 
 #### Examples
 
 ```ruby
 windows_font 'Code New Roman.otf'
+
+windows_font 'Custom.otf' do
+  source "https://example.com/Custom.otf"
+end
 ```
 
 ### windows_http_acl

--- a/resources/font.rb
+++ b/resources/font.rb
@@ -19,6 +19,8 @@
 # limitations under the License.
 #
 
+require 'uri'
+
 property :name, String, name_property: true
 property :source, String, required: false
 
@@ -40,7 +42,7 @@ action_class do
     if new_resource.source
       remote_file font_file do
         action  :nothing
-        source  "file://#{new_resource.source}"
+        source source_uri
         path    win_friendly_path(::File.join(ENV['TEMP'], font_file))
       end.run_action(:create)
     else
@@ -76,5 +78,12 @@ action_class do
     require 'win32ole' if RUBY_PLATFORM =~ /mswin|mingw32|windows/
     fonts_dir = WIN32OLE.new('WScript.Shell').SpecialFolders('Fonts')
     ::File.exist?(win_friendly_path(::File.join(fonts_dir, new_resource.name)))
+  end
+
+  def source_uri
+    if new_resource.source
+      uri = URI.parse(new_resource.source)
+      uri.scheme ? new_resource.source : "file://#{new_resource.source}"
+    end
   end
 end


### PR DESCRIPTION
Signed-off-by: Jon Burgess <jkburges@gmail.com>

### Description

Fonts can now be pulled from an http source (e.g. S3)

### Issues Resolved

It just makes it easier to install fonts sourced from a remote location.  One doesn't have to have a separate `remote_file` resource to do the job.

Also, solves a particular problem I was having when first fetching the font to the chef cache dir, and ending up with (invalid) file URIs such as "file://C:\chef\cache/fonts/Amatic-Bold.ttf was an invalid URI".

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>

master appears to be failing currently

- [ ] New functionality includes testing.
I need some guidance with how to add unit tests for this new functionality

- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
