### PR TITLE
Fix deprecations_namespace_collisions

### DIFF
--- a/resources/zipfile.rb
+++ b/resources/zipfile.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Doug MacEachern (<dougm@vmware.com>)
 # Author:: Seth Chisamore (<schisamo@chef.io>)
-# Author:: Wade Peacock (<wade.peacock@visioncritical.com>) 
+# Author:: Wade Peacock (<wade.peacock@visioncritical.com>)
 # Cookbook:: windows
 # Resource:: zipfile
 #

--- a/resources/zipfile.rb
+++ b/resources/zipfile.rb
@@ -1,6 +1,7 @@
 #
 # Author:: Doug MacEachern (<dougm@vmware.com>)
 # Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Wade Peacock (<wade.peacock@visioncritical.com>) 
 # Cookbook:: windows
 # Resource:: zipfile
 #
@@ -33,7 +34,7 @@ action :unzip do
   Chef::Log.debug("unzip #{new_resource.source} => #{new_resource.path} (overwrite=#{new_resource.overwrite})")
 
   cache_file_path = if new_resource.source =~ %r{^(file|ftp|http|https):\/\/} # http://rubular.com/r/DGoIWjLfGI
-                      uri = as_uri(source)
+                      uri = as_uri(new_resource.source)
                       local_cache_path = "#{Chef::Config[:file_cache_path]}/#{::File.basename(::URI.unescape(uri.path))}"
                       Chef::Log.debug("Caching a copy of file #{new_resource.source} at #{cache_file_path}")
 


### PR DESCRIPTION
### Description

Fixes deprecations_namespace_collisions warning

### Issues Resolved

```
 - C:/Users/vagrant/AppData/Local/Temp/kitchen/cache/cookbooks/windows/resources/zipfile.rb:36:in `block in class_from_file'
          See https://docs.chef.io/deprecations_namespace_collisions.html for further details.
```

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
