### PR TITLE
Adds additional certificate store names

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,20 @@ Installs a certificate into the Windows certificate store from a file, and grant
 - `source` - name attribute. The source file (for create and acl_add), thumbprint (for delete and acl_add) or subject (for delete).
 - `pfx_password` - the password to access the source if it is a pfx file.
 - `private_key_acl` - array of 'domain\account' entries to be granted read-only access to the certificate's private key. This is not idempotent.
-- `store_name` - the certificate store to manipulate. One of MY (default : personal store), CA (trusted intermediate store) or ROOT (trusted root store).
+- `store_name` - the certificate store to manipulate. One of:
+  - MY (Personal)
+  - CA (Intermediate Certification Authorities)
+  - ROOT (Trusted Root Certification Authorities)
+  - TRUSTEDPUBLISHER (Trusted Publishers)
+  - CLIENTAUTHISSUER (Client Authentication Issuers)
+  - REMOTE DESKTOP (Remote Desktop)
+  - TRUSTEDDEVICES (Trusted Devices)
+  - WEBHOSTING (Web Hosting)
+  - AUTHROOT (Third-Party Root Certification Authorities)
+  - TRUSTEDPEOPLE (Trusted People)
+  - SMARTCARDROOT (Smart Card Trusted Roots)
+  - TRUST (Enterprise Trust)
+  - DISALLOWED (Untrusted Certificates)
 - `user_store` - if false (default) then use the local machine store; if true then use the current user's store.
 
 #### Examples
@@ -106,7 +119,19 @@ Binds a certificate to an HTTP port in order to enable TLS communication.
 - `address` - the address to bind against. Default is 0.0.0.0 (all IP addresses).
 - `port` - the port to bind against. Default is 443.
 - `app_id` - the GUID that defines the application that owns the binding. Default is the values used by IIS.
-- `store_name` - the store to locate the certificate in. One of MY (default : personal store), CA (trusted intermediate store) or ROOT (trusted root store).
+- `store_name` - the store to locate the certificate in. One of:
+  - MY (Personal)
+  - CA (Intermediate Certification Authorities)
+  - ROOT (Trusted Root Certification Authorities)
+  - TRUSTEDPUBLISHER (Trusted Publishers)
+  - CLIENTAUTHISSUER (Client Authentication Issuers)
+  - REMOTE DESKTOP (Remote Desktop)
+  - TRUSTEDDEVICES (Trusted Devices)
+  - WEBHOSTING (Web Hosting)
+  - AUTHROOT (Third-Party Root Certification Authorities)
+  - TRUSTEDPEOPLE (Trusted People)
+  - SMARTCARDROOT (Smart Card Trusted Roots)
+  - TRUST (Enterprise Trust)
 
 #### Examples
 

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -23,7 +23,7 @@ include Windows::Helper
 property :source, String, name_property: true, required: true
 property :pfx_password, String
 property :private_key_acl, Array
-property :store_name, String, default: 'MY', regex: /^(?:MY|CA|ROOT|TrustedPublisher|TRUSTEDPEOPLE)$/
+property :store_name, String, default: 'MY', equal_to: ['TRUSTEDPUBLISHER', 'TrustedPublisher', 'CLIENTAUTHISSUER', 'REMOTE DESKTOP', 'ROOT', 'TRUSTEDDEVICES', 'WEBHOSTING', 'CA', 'AUTHROOT', 'TRUSTEDPEOPLE', 'MY', 'SMARTCARDROOT', 'TRUST', 'DISALLOWED']
 property :user_store, [true, false], default: false
 
 action :create do

--- a/resources/certificate_binding.rb
+++ b/resources/certificate_binding.rb
@@ -27,7 +27,7 @@ property :name_kind, Symbol, equal_to: [:hash, :subject], default: :subject
 property :address, String, default: '0.0.0.0'
 property :port, Integer, default: 443
 property :app_id, String, default: '{4dc3e181-e14b-4a21-b022-59fc669b0914}'
-property :store_name, String, default: 'MY', regex: /^(?:MY|CA|ROOT)$/
+property :store_name, String, default: 'MY', equal_to: ['TRUSTEDPUBLISHER', 'CLIENTAUTHISSUER', 'REMOTE DESKTOP', 'ROOT', 'TRUSTEDDEVICES', 'WEBHOSTING', 'CA', 'AUTHROOT', 'TRUSTEDPEOPLE', 'MY', 'SMARTCARDROOT', 'TRUST']
 property :exists, [true, false], desired_state: true
 
 load_current_value do |desired|


### PR DESCRIPTION
### Description

Adds additional certificate store names to the `certificate` and `certificate_binding` resources.

- Switches from `regex` to `equal_to`
- Maintains `TrustedPublisher` within `certificate` since that's how it was previously defined and we're case-sensitive
- Does not allow utilizing the DISALLOWED store on `certificate_binding`

### Issues Resolved

#297 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
