### PR TITLE
Enable dism_features script for other languages windows

### DIFF
--- a/files/dism_features.rb
+++ b/files/dism_features.rb
@@ -30,7 +30,7 @@ Ohai.plugin(:DismFeatures) do
              cmd
            end
     # Grab raw feature information from dism command line
-    raw_list_of_features = shell_out("#{dism} /Get-Features /Online /Format:Table").stdout
+    raw_list_of_features = shell_out("#{dism} /Get-Features /Online /Format:Table /English").stdout
     # Split stdout into an array by windows line ending
     features_list = raw_list_of_features.split("\r\n")
     features_list.each do |feature_details_raw|


### PR DESCRIPTION
When you run this script for other languages windows the enable/disable detection didn't work. The /English parameter corrects the problem.

Signed-off-by: Daniel Masarin <daniel.masarin@gmail.com>

### Description

Enable the dism_feature.rb script to run on machine in other languages than english

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Tests was realized in Windows 10 x64. I can't test on other systems because I don't have the licenses.
