### PR TITLE
Fix certificate resource always reporting as updated

### DIFF
--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -35,13 +35,11 @@ action :create do
   guard_script = cert_script(false) <<
                  cert_exists_script(hash)
 
-  converge_by("adding certificate #{new_resource.source} into #{new_resource.store_name} to #{cert_location}\\#{new_resource.store_name}") do
-    powershell_script new_resource.name do
-      guard_interpreter :powershell_script
-      convert_boolean_return true
-      code code_script
-      not_if guard_script
-    end
+  powershell_script "adding certificate #{new_resource.source} into #{new_resource.store_name} to #{cert_location}\\#{new_resource.store_name}" do
+    guard_interpreter :powershell_script
+    convert_boolean_return true
+    code code_script
+    not_if guard_script
   end
 end
 
@@ -60,13 +58,11 @@ action :acl_add do
   code_script << acl_script(hash)
   guard_script << cert_exists_script(hash)
 
-  converge_by("setting the acls on #{new_resource.source} in #{cert_location}\\#{new_resource.store_name}") do
-    powershell_script new_resource.name do
-      guard_interpreter :powershell_script
-      convert_boolean_return true
-      code code_script
-      only_if guard_script
-    end
+  powershell_script "setting the acls on #{new_resource.source} in #{cert_location}\\#{new_resource.store_name}" do
+    guard_interpreter :powershell_script
+    convert_boolean_return true
+    code code_script
+    only_if guard_script
   end
 end
 
@@ -90,13 +86,11 @@ foreach ($c in #{cert_command})
 EOH
   end
   guard_script = "@(#{cert_command}).Count -gt 0\n"
-  converge_by("Removing certificate #{new_resource.source} from #{cert_location}\\#{new_resource.store_name}") do
-    powershell_script new_resource.name do
-      guard_interpreter :powershell_script
-      convert_boolean_return true
-      code code_script
-      only_if guard_script
-    end
+  powershell_script "Removing certificate #{new_resource.source} from #{cert_location}\\#{new_resource.store_name}" do
+    guard_interpreter :powershell_script
+    convert_boolean_return true
+    code code_script
+    only_if guard_script
   end
 end
 

--- a/test/cookbooks/test/recipes/certificate.rb
+++ b/test/cookbooks/test/recipes/certificate.rb
@@ -13,6 +13,12 @@ windows_certificate '2796bae63f1801e277261ba0d77770028f20eee4' do
   action :delete
 end
 
+# this resource should always be "up to date"
+windows_certificate 'duplicate delete' do
+  source '2796bae63f1801e277261ba0d77770028f20eee4'
+  action :delete
+end
+
 # Generate using:
 # makecert -r -n "CN=ChefDummyCertForTest" -pe -ss My -sv test-cert.pvk test-cert.cer
 # pvk2pfx -pvk test-cert.pvk -spc test-cert.cer -pfx test-cert.pfx -po chef123


### PR DESCRIPTION
### Description

The certificate resource always reports as having created/deleted the certificate even if it doesn't make a change. This is because the `powershell_script` resource that does the work is wrapped by a call to `converge_by`.

### Issues Resolved

- #476
