### PR TITLE
Change install feature guards for win2008r2

### DIFF
--- a/resources/feature_powershell.rb
+++ b/resources/feature_powershell.rb
@@ -42,14 +42,22 @@ action_class do
 
   def installed?
     @installed ||= begin
-      cmd = powershell_out("(Get-WindowsFeature #{to_array(new_resource.feature_name).join(',')} | ?{$_.InstallState -ne \'Installed\'}).count", timeout: new_resource.timeout)
+      cmd = if node['os_version'].to_f < 6.2
+              powershell_out("Import-Module ServerManager; @(Get-WindowsFeature #{to_array(new_resource.feature_name).join(',')} | ?{$_.Installed -ne $TRUE}).count", timeout: new_resource.timeout)
+            else
+              powershell_out("@(Get-WindowsFeature #{to_array(new_resource.feature_name).join(',')} | ?{$_.InstallState -ne \'Installed\'}).count", timeout: new_resource.timeout)
+            end
       cmd.stderr.empty? && cmd.stdout.chomp.to_i == 0
     end
   end
 
   def available?
     @available ||= begin
-      cmd = powershell_out("(Get-WindowsFeature #{to_array(new_resource.feature_name).join(',')} | ?{$_.InstallState -ne \'Removed\'}).count", timeout: new_resource.timeout)
+      cmd = if node['os_version'].to_f < 6.2
+              powershell_out("Import-Module ServerManager; @(Get-WindowsFeature #{to_array(new_resource.feature_name).join(',')}).count", timeout: new_resource.timeout)
+            else
+              powershell_out("@(Get-WindowsFeature #{to_array(new_resource.feature_name).join(',')} | ?{$_.InstallState -ne \'Removed\'}).count", timeout: new_resource.timeout)
+            end
       cmd.stderr.empty? && cmd.stdout.chomp.to_i > 0
     end
   end


### PR DESCRIPTION
Signed-off-by: Krzysztof Kowalczyk <krzkowalczyk@gmail.com>

### Description

Changes the way how installed? and available? functions are executed on windows 2008r2, as currently used attribute InstallState is not available on this system. Import-Module ServerManager is included in cmd.

It forces to converts the result from Get-WindowsFeature into array, as when executed on single feature, count method doesn't return properly the count.

### Issues Resolved

[#508](https://github.com/chef-cookbooks/windows/issues/508)
[#480](https://github.com/chef-cookbooks/windows/issues/480)

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
