### PR TITLE
Fixing couple of bugs in windows_share

### DIFF
--- a/resources/share.rb
+++ b/resources/share.rb
@@ -230,7 +230,7 @@ action_class do
         )
         #Create the Trusteee Object
         $Trustee = ([WMIClass] "\\\\$env:computername\\root\\cimv2:Win32_Trustee").CreateInstance()
-        $account = get-wmiobject Win32_Account -filter "Name like '$Name' and Domain like '$Domain'"
+        $account = get-wmiobject Win32_Account -filter "Name = '$Name' and Domain = '$Domain'"
         $accountSID = [WMI] "\\\\$env:ComputerName\\root\\cimv2:Win32_SID.SID='$($account.sid)'"
 
         $Trustee.Domain = $Domain

--- a/resources/share.rb
+++ b/resources/share.rb
@@ -147,7 +147,7 @@ action_class do
   end
 
   def different_members?(permission_type)
-    !(current_resource.send(permission_type.to_sym) - new_resource.send(permission_type.to_sym).map(&:downcase)).empty? &&
+    !(current_resource.send(permission_type.to_sym) - new_resource.send(permission_type.to_sym).map(&:downcase)).empty? ||
       !(new_resource.send(permission_type.to_sym).map(&:downcase) - current_resource.send(permission_type.to_sym)).empty?
   end
 


### PR DESCRIPTION
### Description
This change proposes a couple of bug fixes:
- When using LIKE for comparison of user and domain, powershell script hangs. This probably uses some index rather doing full search against database. Since wildcard is not used in LIKE statement, we can better replace it with equality sign "=".
- Detection of permissions changes doesn't work due to wrong logical statement.

### Issues Resolved

- The first Chef run create share, but doesn't set permissions. We have "everyone with read access". This is because change in share's permissions cannot be detected correctly
- The second Chef run just hangs for unknown time. This is because LIKE makes full search for filtering.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
