### PR TITLE
Added missing parentheses around PersistKeySet flag that was preventing PowerShell from creating X509Certificate2 object

### DIFF
--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -106,7 +106,7 @@ action_class do
     if ::File.extname(file.downcase) == '.pfx'
       cert_script << ", \"#{new_resource.pfx_password}\""
       if persist && new_resource.user_store
-        cert_script << ', [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet'
+        cert_script << ', ([System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet)'
       elsif persist
         cert_script << ', ([System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet -bor [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::MachineKeyset)'
       end


### PR DESCRIPTION
…ng PowerShell from creating X509Certificate2 object. Obvious fix.

### Description

This change allows Powershell X509Certificate2 object to be created and consequently, allows to import a certificate with the windows_certificate resource when user_store is set to true.

### Issues Resolved

This change resolves issue #519: windows_certificate fails to import certificate under Current User store (https://github.com/chef-cookbooks/windows/issues/519).

### Check List

- [x ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
