### PR TITLE
[GH-521] - undefined method for 'ipv4_address'

### DIFF
--- a/resources/printer_port.rb
+++ b/resources/printer_port.rb
@@ -42,8 +42,8 @@ end
 load_current_value do |desired|
   name desired.name
   ipv4_address desired.ipv4_address
-  port_name desired.port_name || "IP_#{@new_resource.ipv4_address}"
-  exists port_exists?(desired.port_name)
+  port_name desired.port_name || "IP_#{desired.ipv4_address}"
+  exists port_exists?(desired.port_name || "IP_#{desired.ipv4_address}")
   # TODO: Set @current_resource port properties from registry
 end
 


### PR DESCRIPTION
* Fixes ipv4_address on line 45
* Logic to properly handle null port_name property found after fixing ipv4_address

Signed-off-by: Jeff Mery <jmery@chef.io>

### Description

[Describe what this change achieves]

### Issues Resolved

Fixes #521 .  Addresses secondary issue with `port_name` logic found after fix.

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
