### PR TITLE
Support binding certificates to a hostname as well as an IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,10 @@ Binds a certificate to an HTTP port in order to enable TLS communication.
 
 - `cert_name` - name attribute. The thumbprint(hash) or subject that identifies the certificate to be bound.
 - `name_kind` - indicates the type of cert_name. One of :subject (default) or :hash.
-- `address` - the address to bind against. Default is 0.0.0.0 (all IP addresses).
+- `address` - the address to bind against. Default is 0.0.0.0 (all IP addresses). One of:
+  - IP v4 address `1.2.3.4`
+  - IP v6 address `[::1]`
+  - Host name `www.foo.com`
 - `port` - the port to bind against. Default is 443.
 - `app_id` - the GUID that defines the application that owns the binding. Default is the values used by IIS.
 - `store_name` - the store to locate the certificate in. One of:

--- a/test/cookbooks/test/recipes/certificate.rb
+++ b/test/cookbooks/test/recipes/certificate.rb
@@ -39,3 +39,9 @@ windows_certificate_binding '444-appid' do
   port 444
   app_id '{00000000-0000-0000-0000-000000000000}'
 end
+
+windows_certificate_binding '443-hostname' do
+  cert_name 'ChefDummyCertForTest'
+  store_name 'CA'
+  address 'www.chef.io'
+end

--- a/test/integration/certificate/pester/minimal.certificate.Tests.ps1
+++ b/test/integration/certificate/pester/minimal.certificate.Tests.ps1
@@ -34,5 +34,11 @@ describe 'test::certificate' {
       $binding[5] | Should Match ' : 5081f667f1ef005d0ec39fa3e30aa71b4fd84eb6$'
       $binding[6] | Should Match ' : {00000000-0000-0000-0000-000000000000}\s*$'
     }
+
+    it "binds test-cert to port 443 with host www.chef.io" {
+      $binding = netsh http show sslcert hostnameport=www.chef.io:443
+      $binding[4] | Should Match ' : www.chef.io:443\s*$'
+      $binding[5] | Should Match ' : 5081f667f1ef005d0ec39fa3e30aa71b4fd84eb6$'
+    }
   }
 }


### PR DESCRIPTION
### Description

In order to support SNI on a https connection the certificate has to be bound to a hostname rather than an IP address. The `netsh` command uses a different syntax to do this.

A regex is used to determine whether the `address` property is an IP v4/v6 address or a hostname
