### PR TITLE
Avoid extra file IO every time we run windows_feature

### DIFF
--- a/resources/feature.rb
+++ b/resources/feature.rb
@@ -25,8 +25,6 @@ property :management_tools, [true, false], default: false
 property :install_method, Symbol, equal_to: [:windows_feature_dism, :windows_feature_powershell, :windows_feature_servermanagercmd]
 property :timeout, Integer, default: 600
 
-include Windows::Helper
-
 action :install do
   run_default_provider :install
 end
@@ -43,10 +41,8 @@ action_class do
   def locate_default_provider
     if new_resource.install_method
       new_resource.install_method
-    elsif ::File.exist?(locate_sysnative_cmd('dism.exe'))
-      :windows_feature_dism
     else
-      :windows_feature_powershell
+      :windows_feature_dism
     end
   end
 

--- a/resources/feature_powershell.rb
+++ b/resources/feature_powershell.rb
@@ -1,7 +1,10 @@
 #
 # Author:: Greg Zapp (<greg.zapp@gmail.com>)
+#
 # Cookbook:: windows
 # Resource:: feature_powershell
+#
+# Copyright:: 2015-2018, Chef Software, Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +26,6 @@ property :timeout, Integer, default: 600
 property :management_tools, [true, false], default: false
 
 include Chef::Mixin::PowershellOut
-include Windows::Helper
 
 action :install do
   Chef::Log.warn("Requested feature #{new_resource.feature_name.join(',')} is not available on this system.") unless available?


### PR DESCRIPTION
We were checking file paths for dism.exe on every run when the sensible default at this point is to just assume DISM unless someone specifies Powershell. The previous logic went back to the days of servermanagercmd vs dism where we only used dism if they had it, but we don't support Windows 2003 / Windows 2008 anymore so this just isn't an issue.