### PR TITLE
Action added to windows_user_privilege to remove a privilege

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,7 @@ Adds the `principal` (User/Group) to the specified privileges (such as `Logon as
 #### Actions
 
 - `:add` - add the specified privileges to the `principal`
+- `:remove` - remove the specified privilege of the `principal`
 
 #### Properties
 
@@ -701,6 +702,15 @@ Grant the Administrator user the `Logon as a batch job` and `Logon as a service`
 ```ruby
 windows_user_privilege 'Administrator' do
   privilege %w(SeBatchLogonRight SeServiceLogonRight)
+end
+```
+
+Remove `Logon as a batch job` privilege of Administrator.
+
+```ruby
+windows_user_privilege 'Administrator' do
+  privilege %w(SeBatchLogonRight)
+  action :remove
 end
 ```
 

--- a/kitchen.appveyor.yml
+++ b/kitchen.appveyor.yml
@@ -9,10 +9,10 @@ driver:
 
 provisioner:
   name: chef_zero
-  deprecations_as_errors: true
+  deprecations_as_errors: false
   product_name: chef
-  product_version: 13.1
   require_omnibus: true
+  channel: current # Can be removed when Chef 14.4 is released
 
 platforms:
   - name: windows-2012R2
@@ -33,3 +33,6 @@ suites:
   - name: pagefile
     run_list:
       - recipe[test::pagefile]
+  - name: user_privilege
+    run_list:
+      - recipe[test::user_privilege]

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -10,10 +10,10 @@ transport:
 
 provisioner:
   name: chef_zero
-  deprecations_as_errors: true
+  deprecations_as_errors: false
   product_name: chef
-  product_version: 13.1
   require_omnibus: true
+  channel: current # Can be removed when Chef 14.4 is released
 
 verifier:
   name: inspec

--- a/test/cookbooks/test/recipes/user_privilege.rb
+++ b/test/cookbooks/test/recipes/user_privilege.rb
@@ -1,4 +1,23 @@
+# Adding 5 Privileges
 windows_user_privilege 'vagrant' do
-  privilege %w(SeBatchLogonRight SeServiceLogonRight)
+  privilege %w(SeIncreaseQuotaPrivilege SeServiceLogonRight SeTimeZonePrivilege SeCreateTokenPrivilege SeBackupPrivilege)
   action :add
+end
+
+# Removing 3 of them
+windows_user_privilege 'vagrant' do
+  privilege %w(SeIncreaseQuotaPrivilege SeServiceLogonRight SeTimeZonePrivilege)
+  action :remove
+end
+
+# Removing 1 from already removed
+windows_user_privilege 'vagrant' do
+  privilege %w(SeIncreaseQuotaPrivilege)
+  action :remove
+end
+
+# Removing few present & few already removed
+windows_user_privilege 'vagrant' do
+  privilege %w(SeServiceLogonRight SeTimeZonePrivilege SeCreateTokenPrivilege SeBackupPrivilege)
+  action :remove
 end


### PR DESCRIPTION
### Description

- Added functionality to remove account privileges in `windows_user_privilege` resource
- Updated kitchen.yml and kitchen.appveyor.yml
  - There is a test dependancy on `current release(14.3.39)` and above
  - Some resources are already included in Chef-Client 14.1 ([reference](https://docs.chef.io/resource_reference.html)) and throwing cookbook comilation error: 'DeprecatedFeatureError', hence skipping the same as warning
- Updated `Readme` with examples
- Added test recipes

### Testing

Successfully tested these changes on local machine using Win2012R2, current latest release of chef (14.3.39) where library methods to remove account rights are [added](https://github.com/chef/chef/pull/7445)

Used the following kitchen configuration for local testing:
```
kitchen.yml:

driver:
  name: vagrant
  customize:
    cpus: 2
    memory: 4096

transport:
  name: winrm
  elevated: true

provisioner:
  name: chef_zero
  deprecations_as_errors: true
  product_name: chef
  channel: current
  require_omnibus: true

verifier:
  name: inspec

platforms:
  - name: windows-2012R2
    driver:
      customize:
        memory: 2048

suites:
  - name: user_privilege
    run_list:
      - recipe[test::user_privilege]

```

Result:
```
PS> kitchen converge
-----> Starting Kitchen (v1.21.2)
-----> Converging <user-privilege-windows-2012R2>...
       Preparing files for transfer
       Preparing dna.json
       Resolving cookbook dependencies with Berkshelf 7.0.2...
       Removing non-cookbook files before transfer
       Preparing validation.pem
       Preparing client.rb

       ModuleType Version    Name                                ExportedCommands
       ---------- -------    ----                                ----------------
       Script     0.0        Omnitruck                           {Get-ProjectMetada...
       chef installation detected
       install_strategy set to 'once'
       Nothing to install
       Transferring files to <user-privilege-windows-2012R2>
       Starting Chef Client, version 14.3.39
       resolving cookbooks for run list: ["test::user_privilege"]
       Synchronizing Cookbooks:
         - test (0.0.1)
         - windows (4.3.3)
       Installing Cookbook Gems:
       Compiling Cookbooks...
       Converging 4 resources
       Recipe: test::user_privilege
         * windows_user_privilege[vagrant] action add
           - adding user privilege SeBackupPrivilege
           - adding user privilege SeCreateTokenPrivilege
           - adding user privilege SeIncreaseQuotaPrivilege
           - adding user privilege SeServiceLogonRight
           - adding user privilege SeTimeZonePrivilege
         * windows_user_privilege[vagrant] action remove
           - removing user privilege SeIncreaseQuotaPrivilege
           - removing user privilege SeServiceLogonRight
           - removing user privilege SeTimeZonePrivilege
         * windows_user_privilege[vagrant] action remove (up to date)
         * windows_user_privilege[vagrant] action remove
           - removing user privilege SeBackupPrivilege
           - removing user privilege SeCreateTokenPrivilege

       Running handlers:
       Running handlers complete
       Chef Client finished, 3/4 resources updated in 04 seconds
       Downloading files from <user-privilege-windows-2012R2>
       Finished converging <user-privilege-windows-2012R2> (0m23.28s).
-----> Kitchen is finished. (0m32.08s)
```

Thoroughly tested privileges using similar [script](https://gallery.technet.microsoft.com/Grant-Revoke-Query-user-26e259b0) and the results were as per the expectations

### Issues Resolved
#228
[#6716](https://github.com/chef/chef/issues/6716)


Signed-off-by: [Nimesh](<nimesh.patni@msystechnologies.com>)

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
