### PR TITLE
WIP Fixes of win32-certstore required 0.1.8 also it upgrade chef_gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,4 @@
 source 'https://rubygems.org'
 
 gem 'community_cookbook_releaser'
-gem 'win32-certstore' # until this is in core chef
+gem 'win32-certstore', '>= 0.1.8'

--- a/kitchen.appveyor.yml
+++ b/kitchen.appveyor.yml
@@ -7,12 +7,16 @@ driver:
   username: <%= ENV["machine_user"] %>
   password: <%= ENV["machine_pass"] %>
 
+transport:
+  name: winrm
+  elevated: true
+
 provisioner:
   name: chef_zero
-  deprecations_as_errors: false
+  deprecations_as_errors: true
   product_name: chef
+  product_version: 14.4
   require_omnibus: true
-  channel: current # Can be removed when Chef 14.4 is released
 
 platforms:
   - name: windows-2012R2

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -10,10 +10,10 @@ transport:
 
 provisioner:
   name: chef_zero
-  deprecations_as_errors: false
+  deprecations_as_errors: true
   product_name: chef
+  product_version: 14.4
   require_omnibus: true
-  channel: current # Can be removed when Chef 14.4 is released
 
 verifier:
   name: inspec

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -93,7 +93,7 @@ action_class do
     Chef::Log.debug('Did not find win32-certstore >= 0.1.8 gem installed. Installing now')
     chef_gem 'win32-certstore' do
       compile_time true
-      action :install
+      action :upgrade
     end
 
     require 'win32-certstore'

--- a/test/integration/pagefile/pagefile_spec.rb
+++ b/test/integration/pagefile/pagefile_spec.rb
@@ -1,4 +1,4 @@
-describe file('C:\pagefile.sys') do
+describe file('c:/pagefile.sys') do
   it { should exist }
 end
 


### PR DESCRIPTION
Signed-off-by: piyushawasthi <piyush.awasthi@msystechnologies.com>

### Description

Fixes of win32-certstore required 0.1.8

### Issues Resolved

https://github.com/chef-cookbooks/windows/issues/566

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
