### PR TITLE
Fix a typo in windows_feature_dism resource name

### DIFF
--- a/resources/feature_dism.rb
+++ b/resources/feature_dism.rb
@@ -19,7 +19,7 @@
 #
 
 chef_version_for_provides '< 14.0' if respond_to?(:chef_version_for_provides)
-resource_name :windows_feature_name
+resource_name :windows_feature_dism
 
 property :feature_name, [Array, String], coerce: proc { |x| to_formatted_array(x) }, name_property: true
 property :source, String


### PR DESCRIPTION
Signed-off-by: Nikolai Bessonov <bessonov.na@icloud.com>

### Description
Fix a typo in `windows_feature_dism` resource name. Typo was indrodused in https://github.com/chef-cookbooks/windows/commit/9342c9c994b98b091f2687d4f44a4d47290fb0a7

```bash
 [2018-10-08T05:47:02-07:00] FATAL: Chef::Exceptions::NoSuchResourceType: windows_feature[NetFx3] (gf_powerchute::default line 9) had an error: Chef::Exceptions::NoSuchResourceType: Cannot find a resource for windows_feature_dism on windows version 10.0.14393
```

