### PR TITLE
Fix exception message when retrieving SMB share access in windows_share resource

### DIFF
--- a/resources/share.rb
+++ b/resources/share.rb
@@ -102,7 +102,7 @@ load_current_value do |desired|
 
   # we raise here instead of warning like above because we'd only get here if the above Get-SmbShare
   # command was successful and that continuing would leave us with 1/2 known state
-  raise "Could not determine #{desired.share_name} share permissions by running '#{perm_cmd}'" if ps_perm_results.error?
+  raise "Could not determine #{desired.share_name} share permissions by running '#{perm_state_cmd}'" if ps_perm_results.error?
 
   Chef::Log.debug("The Get-SmbShareAccess results were #{ps_perm_results.stdout}")
 


### PR DESCRIPTION
Signed-off-by: Jeffrey Coe <jeffrey.coe@cerner.com>

### Description

When an exception is thrown when attempting to gather the ACLs for an SMB share, a variable used in the log message results in an error message stating an undefined variable or method name was specified.  See below for the error from the Chef client log file.


    NoMethodError
    -------------
    undefined method `perm_cmd' for Custom resource windows_share from cookbook windows

    Resource Declaration:
    ---------------------
    # In C:/Users/TEST/AppData/Local/Temp/kitchen/cache/cookbooks/test/recipes/file_shares.rb

    43: windows_share 'create_test_windows_share' do
    44:   share_name 'Test Share'
    45:   path node['test_cookbook']['share_dir']
    46:   full_users share_perms['full_users']
    47:   change_users share_perms['change_users']
    48:   read_users share_perms['read_users']
    49:   action :create
    50: end
    51:

### Issues Resolved

N/A

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
