### PR TITLE
Deprecated win_friendly_path helper in favor of built-in helpers

### DIFF
--- a/libraries/windows_helper.rb
+++ b/libraries/windows_helper.rb
@@ -22,6 +22,7 @@ require 'Win32API' if Chef::Platform.windows?
 require 'chef/exceptions'
 require 'openssl'
 require 'chef/mixin/powershell_out'
+require 'chef/util/path_helper'
 
 module Windows
   module Helper
@@ -32,6 +33,7 @@ module Windows
     # returns windows friendly version of the provided path,
     # ensures backslashes are used everywhere
     def win_friendly_path(path)
+      Chef::Log.warn('The win_friendly_path helper has been deprecated and will be removed from the next major release of the windows cookbook. Please update any cookbooks using this helper to instead require `chef/util/path_helper` and then use `Chef::Util::PathHelper.cleanpath`.')
       path.gsub(::File::SEPARATOR, ::File::ALT_SEPARATOR || '\\') if path
     end
 
@@ -80,7 +82,7 @@ module Windows
           cache_file_path = source
         end
 
-        windows_path ? win_friendly_path(cache_file_path) : cache_file_path
+        windows_path ? Chef::Util::PathHelper.cleanpath(cache_file_path) : cache_file_path
       end
     end
 

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -19,6 +19,8 @@
 # limitations under the License.
 #
 
+require 'chef/util/path_helper'
+
 chef_version_for_provides '< 14.7' if respond_to?(:chef_version_for_provides)
 resource_name :windows_certificate
 
@@ -168,7 +170,7 @@ action_class do
 
   def cert_script(persist)
     cert_script = '$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2'
-    file = win_friendly_path(new_resource.source)
+    file = Chef::Util::PathHelper.cleanpath(new_resource.source)
     cert_script << " \"#{file}\""
     if ::File.extname(file.downcase) == '.pfx'
       cert_script << ", \"#{new_resource.pfx_password}\""

--- a/resources/zipfile.rb
+++ b/resources/zipfile.rb
@@ -21,6 +21,8 @@
 # limitations under the License.
 #
 
+require 'chef/util/path_helper'
+
 property :path, String, name_property: true
 property :source, String
 property :overwrite, [true, false], default: false
@@ -46,7 +48,7 @@ action :unzip do
                       new_resource.source
                     end
 
-  cache_file_path = win_friendly_path(cache_file_path)
+  cache_file_path = Chef::Util::PathHelper.cleanpath(cache_file_path)
 
   converge_by("unzip #{new_resource.source}") do
     ruby_block 'Unzipping' do


### PR DESCRIPTION
We have Chef::Util::PathHelper.cleanpath, which is the built-in equiv of this helper. Deprecate and it and push anyone using it towards the built-in method.

Signed-off-by: Tim Smith <tsmith@chef.io>