### PR TITLE
windows_share: Fix idempotency by not adding everyone by default

### DIFF
--- a/resources/share.rb
+++ b/resources/share.rb
@@ -210,6 +210,10 @@ action_class do
 
     Chef::Log.debug("Running '#{share_cmd}' to create the share")
     powershell_out!(share_cmd)
+
+    # New-SmbShare adds the "Everyone" user with read access no matter what so we need to remove it
+    # before we add our permissions
+    revoke_user_permissions(['Everyone'])
   end
 
   # determine what users in the current state don't exist in the desired state
@@ -265,6 +269,8 @@ action_class do
     false
   end
 
+  # revoke user permissions from a share
+  # @param [Array] users
   def revoke_user_permissions(users)
     revoke_command = "Revoke-SmbShareAccess -Name '#{new_resource.share_name}' -AccountName \"#{users.join(',')}\" -Force"
     Chef::Log.debug("Running '#{revoke_command}' to revoke share permissions")

--- a/test/cookbooks/test/recipes/share.rb
+++ b/test/cookbooks/test/recipes/share.rb
@@ -16,6 +16,13 @@ windows_share 'read_only' do
   read_users ['BUILTIN\\Users', 'bob', 'jane']
 end
 
+windows_share 'create read_only again (should not update)' do
+  share_name 'read_only'
+  path 'C:/test_share'
+  description 'a test share'
+  read_users ['BUILTIN\\Users', 'bob', 'jane']
+end
+
 windows_share 'change' do
   path 'C:/test_share'
   change_users ['BUILTIN\\Users']


### PR DESCRIPTION
Out of the box new-smbshare adds read access to the everyone group.
There's no way in the cmdlet to skip this so when we create the share
we'll need to remove it. That way when we run the 2nd time we don't try
to remove that user.

Signed-off-by: Tim Smith <tsmith@chef.io>