### PR TITLE
windows_share: Accounts to be revoked should be provided as an individually quoted string array

### DIFF
--- a/resources/share.rb
+++ b/resources/share.rb
@@ -272,7 +272,7 @@ action_class do
   # revoke user permissions from a share
   # @param [Array] users
   def revoke_user_permissions(users)
-    revoke_command = "Revoke-SmbShareAccess -Name '#{new_resource.share_name}' -AccountName \"#{users.join(',')}\" -Force"
+    revoke_command = "Revoke-SmbShareAccess -Name '#{new_resource.share_name}' -AccountName \"#{users.join('","')}\" -Force"
     Chef::Log.debug("Running '#{revoke_command}' to revoke share permissions")
     powershell_out!(revoke_command)
   end


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

Solves an issue where if multiple accounts need to be revoked from the share access list, the input is not in a format that can be parsed as a PowerShell string array.

### Issues Resolved

As per discussion in Community Slack and also https://github.com/chef/chef/pull/7959 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
