### PR TITLE
Fix http_acl regex to properly capture SDDL

### DIFF
--- a/resources/http_acl.rb
+++ b/resources/http_acl.rb
@@ -35,7 +35,7 @@ load_current_value do |desired|
     exists true
     url desired.url
     # Checks first for sddl, because it generates user(s)
-    sddl_match = cmd_out.match(/SDDL:\s*(?<sddl>.+)/)
+    sddl_match = cmd_out.match(/SDDL:\s*(?<sddl>\S+)/)
     if sddl_match
       sddl sddl_match['sddl']
     else


### PR DESCRIPTION
### Description

Former regex was incorrect and captured the trailing space and CR.
Since the SDDL format does not include spaces the new regexp is better.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
