### PR TITLE
Fix for windows certificate delete action fails if certificate does not exist

### DIFF
--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -65,7 +65,12 @@ end
 action :delete do
   load_gem
 
-  delete_cert
+  cert_obj = fetch_cert
+  if cert_obj
+    converge_by("Deleting certificate #{new_resource.source} from Store #{new_resource.store_name}") do
+      delete_cert
+    end
+  end
 end
 
 action :fetch do


### PR DESCRIPTION

Signed-off-by: vasu1105 <vasundhara.jagdale@msystechnologies.com>

### Description


### Issues Resolved

Fixes #578 
### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
