### PR TITLE
Font hang

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,3 +9,5 @@ supports         'windows'
 source_url       'https://github.com/chef-cookbooks/windows'
 issues_url       'https://github.com/chef-cookbooks/windows/issues'
 chef_version     '>= 13.4'
+
+gem              'ttfunk'

--- a/resources/font.rb
+++ b/resources/font.rb
@@ -20,6 +20,7 @@
 #
 
 require 'chef/util/path_helper'
+require 'ttfunk'
 
 chef_version_for_provides '< 14.0' if respond_to?(:chef_version_for_provides)
 resource_name :windows_font
@@ -28,19 +29,22 @@ property :font_name, String, name_property: true
 property :source, String, required: false, coerce: proc { |x| x =~ /^.:.*/ ? x.tr('\\', '/').gsub('//', '/') : x }
 
 action :install do
+  retrieve_cookbook_font
+
   if font_exists?
-    Chef::Log.debug("Not installing font: #{new_resource.font_name} as font already installed.")
-  else
-    retrieve_cookbook_font
     install_font
-    del_cookbook_font
+  else
+    Chef::Log.debug("Not installing font: #{new_resource.font_name} as font already installed.")
   end
+
+  del_cookbook_font
 end
 
 action_class do
   # if a source is specified fetch using remote_file. If not use cookbook_file
   def retrieve_cookbook_font
     font_file = new_resource.font_name
+
     if new_resource.source
       remote_file font_file do
         action :nothing
@@ -77,10 +81,19 @@ action_class do
   #
   # @return [Boolean] Is the font is installed?
   def font_exists?
-    require 'win32ole' if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+    font_file = new_resource.font_name
+    font_path = Chef::Util::PathHelper.join(ENV['TEMP'], font_file)
+
+    installed_fonts.include? font_name(font_path)
+  end
+
+  def installed_fonts
     fonts_dir = Chef::Util::PathHelper.join(ENV['windir'], 'fonts')
-    Chef::Log.debug("Seeing if the font at #{Chef::Util::PathHelper.join(fonts_dir, new_resource.font_name)} exists")
-    ::File.exist?(Chef::Util::PathHelper.join(fonts_dir, new_resource.font_name))
+    Dir.glob(Chef::Util::PathHelper.join(fonts_dir, '*')).map { |path| font_name(path) }
+  end
+
+  def font_name(path)
+    ::File.open(path) { |f| TTFunk::File.open(f).name.font_name.first }
   end
 
   # Parse out the schema provided to us to see if it's one we support via remote_file.

--- a/resources/font.rb
+++ b/resources/font.rb
@@ -43,26 +43,24 @@ end
 action_class do
   # if a source is specified fetch using remote_file. If not use cookbook_file
   def retrieve_cookbook_font
-    font_file = new_resource.font_name
-
     if new_resource.source
       remote_file font_file do
         action :nothing
         source source_uri
-        path Chef::Util::PathHelper.join(ENV['TEMP'], font_file)
+        path   font_path
       end.run_action(:create)
     else
       cookbook_file font_file do
         action    :nothing
         cookbook  cookbook_name.to_s unless cookbook_name.nil?
-        path      Chef::Util::PathHelper.join(ENV['TEMP'], font_file)
+        path      font_path
       end.run_action(:create)
     end
   end
 
   # delete the temp cookbook file
   def del_cookbook_font
-    file Chef::Util::PathHelper.join(ENV['TEMP'], new_resource.font_name) do
+    file font_path do
       action :delete
     end
   end
@@ -73,7 +71,7 @@ action_class do
     fonts_dir = WIN32OLE.new('WScript.Shell').SpecialFolders('Fonts')
     folder = WIN32OLE.new('Shell.Application').Namespace(fonts_dir)
     converge_by("install font #{new_resource.font_name} to #{fonts_dir}") do
-      folder.CopyHere(Chef::Util::PathHelper.join(ENV['TEMP'], new_resource.font_name))
+      folder.CopyHere(font_path)
     end
   end
 
@@ -81,9 +79,6 @@ action_class do
   #
   # @return [Boolean] Is the font is installed?
   def font_exists?
-    font_file = new_resource.font_name
-    font_path = Chef::Util::PathHelper.join(ENV['TEMP'], font_file)
-
     installed_fonts.include? font_name(font_path)
   end
 
@@ -120,5 +115,13 @@ action_class do
     end
     Chef::Log.debug('source property does not start with ftp/http. Prepending with file:// as it appears to be a local file.')
     "file://#{new_resource.source}"
+  end
+
+  def font_file
+    new_resource.font_name
+  end
+
+  def font_path
+    Chef::Util::PathHelper.join(ENV['TEMP'], font_file)
   end
 end

--- a/resources/font.rb
+++ b/resources/font.rb
@@ -29,15 +29,13 @@ property :font_name, String, name_property: true
 property :source, String, required: false, coerce: proc { |x| x =~ /^.:.*/ ? x.tr('\\', '/').gsub('//', '/') : x }
 
 action :install do
-  retrieve_cookbook_font
-
-  if font_exists?
-    install_font
-  else
+  if font_file_exists?
     Chef::Log.debug("Not installing font: #{new_resource.font_name} as font already installed.")
+  else
+    retrieve_cookbook_font
+    install_font if font_name_exists?
+    del_cookbook_font
   end
-
-  del_cookbook_font
 end
 
 action_class do
@@ -75,10 +73,20 @@ action_class do
     end
   end
 
-  # Check to see if the font is installed in the fonts dir
+  def font_file_exists?
+    fonts_dir = Chef::Util::PathHelper.join(ENV['windir'], 'fonts')
+    Chef::Log.debug("Seeing if the font at #{Chef::Util::PathHelper.join(fonts_dir, new_resource.font_name)} exists")
+    ::File.exist?(Chef::Util::PathHelper.join(fonts_dir, font_file))
+  end
+
+  def font_name_exists?
+    installed_fonts.include? font_name(font_path)
+  end
+
+  # Check to see if the font file is present in the fonts dir
   #
-  # @return [Boolean] Is the font is installed?
-  def font_exists?
+  # @return [Boolean] Is the font is present?
+  def font_name_exists?
     installed_fonts.include? font_name(font_path)
   end
 


### PR DESCRIPTION
### Description

Fixes a hang with font installs in some cases
    
Steps to repeat the bug:
    
* install a font from file "first_name.ttf" but with internal font name (i.e. in the font metadata within the file) of "my-font"
* install a second font from file "second_name.ttf" but with (same as above) internal font name "my-font"
    
The first font installs fine, the second hangs.
    
This occurs because windows see the second install as an overwrite of the first, and pops up a confirmation dialog box asking whether to override or cancel. Of course, running within the context of chef, this is not visible (but it can be replicated by running the same code from `install_font` in a ruby shell).
    
The fix here is to (hopefully) use the same mechanism as windows to determine font "equality" - i.e. metadata, rather than file name.
    
The downside is that candidate fonts to install must be downloaded first if they are remote, which can slow down provisioning (although not much if everything is running in the same data centre).

### Issues Resolved

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
