### PR TITLE
Grant-SmbShareAccess - remove double quotes for -AccountName parameter

### DIFF
--- a/resources/share.rb
+++ b/resources/share.rb
@@ -243,7 +243,7 @@ action_class do
       # set permissions for a brand new share OR
       # update permissions if the current state and desired state differ
       next unless permissions_need_update?(perm_type)
-      grant_command = "Grant-SmbShareAccess -Name '#{new_resource.share_name}' -AccountName \"#{new_resource.send("#{perm_type}_users").join('","')}\" -Force -AccessRight #{perm_type}"
+      grant_command = "Grant-SmbShareAccess -Name '#{new_resource.share_name}' -AccountName #{new_resource.send("#{perm_type}_users").join('","')} -Force -AccessRight #{perm_type}"
 
       Chef::Log.debug("Running '#{grant_command}' to update the share permissions")
       powershell_out!(grant_command)


### PR DESCRIPTION
### Description

AccountName parameter requires String[], double quotes transform it to usual String and list of accounts couldn't be added to acl. Currently only one account could be added during run.

https://docs.microsoft.com/en-us/powershell/module/smbshare/grant-smbshareaccess?view=win10-ps#optional-parameters

### Issues Resolved

Haven't found related issues.

### Check List

obvious fix
