### PR TITLE
Update to use win32-api and update chef-version

### DIFF
--- a/libraries/version.rb
+++ b/libraries/version.rb
@@ -20,7 +20,8 @@
 
 if RUBY_PLATFORM =~ /mswin|mingw32|windows/
   require_relative 'wmi_helper'
-  require 'Win32API'
+  require 'win32/api'
+  include Win32
 end
 
 module Windows
@@ -147,9 +148,9 @@ module Windows
       'Windows Server 2008 R2' => { major: 6, minor: 1, callable: -> { @product_type != VER_NT_WORKSTATION } },
       'Windows Server 2008' => { major: 6, minor: 0, callable: -> { @product_type != VER_NT_WORKSTATION } },
       'Windows Vista' => { major: 6, minor: 0, callable: -> { @product_type == VER_NT_WORKSTATION } },
-      'Windows Server 2003 R2' => { major: 5, minor: 2, callable: -> { Win32API.new('user32', 'GetSystemMetrics', 'I', 'I').call(SM_SERVERR2) != 0 } },
+      'Windows Server 2003 R2' => { major: 5, minor: 2, callable: -> { API.new('user32', 'GetSystemMetrics', 'I', 'I').call(SM_SERVERR2) != 0 } },
       'Windows Home Server' => { major: 5, minor: 2, callable: -> { (@product_suite & VER_SUITE_WH_SERVER) == VER_SUITE_WH_SERVER } },
-      'Windows Server 2003' => { major: 5, minor: 2, callable: -> { Win32API.new('user32', 'GetSystemMetrics', 'I', 'I').call(SM_SERVERR2) == 0 } },
+      'Windows Server 2003' => { major: 5, minor: 2, callable: -> { API.new('user32', 'GetSystemMetrics', 'I', 'I').call(SM_SERVERR2) == 0 } },
       'Windows XP' => { major: 5, minor: 1 },
       'Windows 2000' => { major: 5, minor: 0 },
     }.freeze unless defined?(WIN_VERSIONS)
@@ -186,10 +187,10 @@ module Windows
 
     private
 
-    # Win32API call to GetSystemMetrics(SM_SERVERR2)
+    # win32/api call to GetSystemMetrics(SM_SERVERR2)
     # returns: The build number if the system is Windows Server 2003 R2; otherwise, 0.
     def sm_serverr2
-      @sm_serverr2 ||= Win32API.new('user32', 'GetSystemMetrics', 'I', 'I').call(SM_SERVERR2)
+      @sm_serverr2 ||= API.new('user32', 'GetSystemMetrics', 'I', 'I').call(SM_SERVERR2)
     end
 
     # query WMI Win32_OperatingSystem for required OS info

--- a/libraries/windows_helper.rb
+++ b/libraries/windows_helper.rb
@@ -18,17 +18,20 @@
 # limitations under the License.
 
 require 'uri'
-require 'Win32API' if Chef::Platform.windows?
 require 'chef/exceptions'
 require 'openssl'
 require 'chef/mixin/powershell_out'
 require 'chef/util/path_helper'
+if Chef::Platform.windows?
+  require 'win32/api'
+  include Win32
+end
 
 module Windows
   module Helper
     AUTO_RUN_KEY = 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run'.freeze unless defined?(AUTO_RUN_KEY)
     ENV_KEY = 'HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'.freeze unless defined?(ENV_KEY)
-    ExpandEnvironmentStrings = Win32API.new('kernel32', 'ExpandEnvironmentStrings', %w(P P L), 'L') if Chef::Platform.windows? && !defined?(ExpandEnvironmentStrings)
+    ExpandEnvironmentStrings = API.new('kernel32', 'ExpandEnvironmentStrings', %w(P P L), 'L') if Chef::Platform.windows? && !defined?(ExpandEnvironmentStrings)
 
     # returns windows friendly version of the provided path,
     # ensures backslashes are used everywhere

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache-2.0'
 description      'Provides a set of useful Windows-specific primitives.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '5.3.0'
+version          '5.3.1'
 supports         'windows'
 source_url       'https://github.com/chef-cookbooks/windows'
 issues_url       'https://github.com/chef-cookbooks/windows/issues'


### PR DESCRIPTION
Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

Replaces the Win32API with win32-api

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
