### PR TITLE
Remove deprecated Win32API

### DIFF
--- a/libraries/version.rb
+++ b/libraries/version.rb
@@ -20,7 +20,6 @@
 
 if RUBY_PLATFORM =~ /mswin|mingw32|windows/
   require_relative 'wmi_helper'
-  require 'Win32API'
 end
 
 module Windows
@@ -64,10 +63,6 @@ module Windows
     VER_NT_SERVER = 0x0000003 unless defined?(VER_NT_SERVER)
     # The operating system is Windows 7, Windows Vista, Windows XP Professional, Windows XP Home Edition, or Windows 2000 Professional.
     VER_NT_WORKSTATION = 0x0000001 unless defined?(VER_NT_WORKSTATION)
-
-    # GetSystemMetrics
-    # The build number if the system is Windows Server 2003 R2; otherwise, 0.
-    SM_SERVERR2 = 89 unless defined?(SM_SERVERR2)
 
     # http://msdn.microsoft.com/en-us/library/ms724358(v=vs.85).aspx
     SKU = {
@@ -147,9 +142,7 @@ module Windows
       'Windows Server 2008 R2' => { major: 6, minor: 1, callable: -> { @product_type != VER_NT_WORKSTATION } },
       'Windows Server 2008' => { major: 6, minor: 0, callable: -> { @product_type != VER_NT_WORKSTATION } },
       'Windows Vista' => { major: 6, minor: 0, callable: -> { @product_type == VER_NT_WORKSTATION } },
-      'Windows Server 2003 R2' => { major: 5, minor: 2, callable: -> { Win32API.new('user32', 'GetSystemMetrics', 'I', 'I').call(SM_SERVERR2) != 0 } },
       'Windows Home Server' => { major: 5, minor: 2, callable: -> { (@product_suite & VER_SUITE_WH_SERVER) == VER_SUITE_WH_SERVER } },
-      'Windows Server 2003' => { major: 5, minor: 2, callable: -> { Win32API.new('user32', 'GetSystemMetrics', 'I', 'I').call(SM_SERVERR2) == 0 } },
       'Windows XP' => { major: 5, minor: 1 },
       'Windows 2000' => { major: 5, minor: 0 },
     }.freeze unless defined?(WIN_VERSIONS)
@@ -185,12 +178,6 @@ module Windows
     end
 
     private
-
-    # Win32API call to GetSystemMetrics(SM_SERVERR2)
-    # returns: The build number if the system is Windows Server 2003 R2; otherwise, 0.
-    def sm_serverr2
-      @sm_serverr2 ||= Win32API.new('user32', 'GetSystemMetrics', 'I', 'I').call(SM_SERVERR2)
-    end
 
     # query WMI Win32_OperatingSystem for required OS info
     def get_os_info

--- a/libraries/version.rb
+++ b/libraries/version.rb
@@ -29,10 +29,6 @@ module Windows
     # Suite Masks
     # Microsoft BackOffice components are installed.
     VER_SUITE_BACKOFFICE = 0x00000004 unless defined?(VER_SUITE_BACKOFFICE)
-    # Windows Server 2003, Web Edition is installed.
-    VER_SUITE_BLADE = 0x00000400 unless defined?(VER_SUITE_BLADE)
-    # Windows Server 2003, Compute Cluster Edition is installed.
-    VER_SUITE_COMPUTE_SERVER = 0x00004000 unless defined?(VER_SUITE_COMPUTE_SERVER)
     # Windows Server 2008 Datacenter, Windows Server 2003, Datacenter Edition, or Windows 2000 Datacenter Server is installed.
     VER_SUITE_DATACENTER = 0x00000080 unless defined?(VER_SUITE_DATACENTER)
     # Windows Server 2008 Enterprise, Windows Server 2003, Enterprise Edition, or Windows 2000 Advanced Server is installed. Refer to the Remarks section for more information about this bit flag.
@@ -47,8 +43,6 @@ module Windows
     VER_SUITE_SMALLBUSINESS = 0x00000001 unless defined?(VER_SUITE_SMALLBUSINESS)
     # Microsoft Small Business Server is installed with the restrictive client license in force. Refer to the Remarks section for more information about this bit flag.
     VER_SUITE_SMALLBUSINESS_RESTRICTED = 0x00000020 unless defined?(VER_SUITE_SMALLBUSINESS_RESTRICTED)
-    # Windows Storage Server 2003 R2 or Windows Storage Server 2003is installed.
-    VER_SUITE_STORAGE_SERVER = 0x00002000 unless defined?(VER_SUITE_STORAGE_SERVER)
     # Terminal Services is installed. This value is always set.
     # If VER_SUITE_TERMINAL is set but VER_SUITE_SINGLEUSERTS is not set, the system is running in application server mode.
     VER_SUITE_TERMINAL = 0x00000010 unless defined?(VER_SUITE_TERMINAL)

--- a/libraries/windows_helper.rb
+++ b/libraries/windows_helper.rb
@@ -18,17 +18,17 @@
 # limitations under the License.
 
 require 'uri'
-require 'Win32API' if Chef::Platform.windows?
 require 'chef/exceptions'
 require 'openssl'
 require 'chef/mixin/powershell_out'
+require 'chef/mixin/windows_env_helper'
 require 'chef/util/path_helper'
 
 module Windows
   module Helper
     AUTO_RUN_KEY = 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run'.freeze unless defined?(AUTO_RUN_KEY)
     ENV_KEY = 'HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'.freeze unless defined?(ENV_KEY)
-    ExpandEnvironmentStrings = Win32API.new('kernel32', 'ExpandEnvironmentStrings', %w(P P L), 'L') if Chef::Platform.windows? && !defined?(ExpandEnvironmentStrings)
+    include Chef::Mixin::WindowsEnvHelper
 
     # returns windows friendly version of the provided path,
     # ensures backslashes are used everywhere
@@ -88,13 +88,10 @@ module Windows
 
     # Expands the environment variables
     def expand_env_vars(path)
-      # We pick 32k because that is the largest it could be:
-      # http://msdn.microsoft.com/en-us/library/windows/desktop/ms724265%28v=vs.85%29.aspx
-      buf = 0.chr * 32 * 1024 # 32k
-      if ExpandEnvironmentStrings.call(path.dup, buf, buf.length) == 0
-        raise Chef::Exceptions::Win32APIError, 'Failed calling ExpandEnvironmentStrings (received 0)'
-      end
-      buf.strip
+      # The windows Env provider does not correctly expand variables in
+      # the PATH environment variable. Ruby expects these to be expanded.
+      # Using Chef::Mixin::WindowsEnvHelper
+      expand_path(path)
     end
 
     def is_package_installed?(package_name) # rubocop:disable Naming/PredicateName


### PR DESCRIPTION
Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

Remove the deprecated Win32API as it is now included in chef.
Update to chef client version >=14

### Issues Resolved


### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
