### PR TITLE
windows_schannel resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the windows cookbook.
 
+## Unreleased
+
+- Added windows_schannel to configure schannel (tls settings for dotnet apps and powershell)
+
 ## 6.0.1 (2019-10-01)
 
 - Update README.md for Windows cookbook suggesting core dns resources (#616) - [@NAshwini](https://github.com/NAshwini)

--- a/README.md
+++ b/README.md
@@ -215,6 +215,20 @@ windows_http_acl 'http://+:50051/' do
 end
 ```
 
+### windows_schannel
+
+Used to configure the schannel security settings in windows, this is used by dotnet apps and powershell to be able to speak to tls 1.2 endpoints
+
+#### Actions
+
+- `configure`: Configures the setting
+
+#### Properties
+
+property                 | type       | default       | description
+------------------------ | ---------- | ------------- | -----------------------------------------------------------------------------------------------------------------------------------------------------------
+`use_strong_crypto`             | True, False     | true | Enables or disables the setting
+
 ### windows_share
 
 `Note`: This resource is now included in Chef 14.7 and later. There is no need to depend on the Windows cookbook for this resource.

--- a/kitchen.appveyor.yml
+++ b/kitchen.appveyor.yml
@@ -33,6 +33,9 @@ suites:
   - name: certificate
     run_list:
       - recipe[test::certificate]
+  - name: schannel
+    run_list:
+      - recipe[test::schannel]
   - name: share
     run_list:
       - recipe[test::share]

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -44,6 +44,9 @@ suites:
   - name: http_acl
     run_list:
       - recipe[test::http_acl]
+  - name: schannel
+    run_list:
+      - recipe[test::schannel]
   - name: share
     run_list:
       - recipe[test::share]

--- a/resources/schannel.rb
+++ b/resources/schannel.rb
@@ -1,0 +1,39 @@
+#
+# Author:: Jason Field (jason.field@calastone.com)
+# Cookbook:: windows
+# Resource:: schannel
+#
+# Copyright:: 2019, Calastone Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+property :use_strong_crypto, [TrueClass, FalseClass], default: true
+
+action :configure do
+  registry_key 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\.NETFramework\\v4.0.30319' do
+    values [{
+      name: 'SchUseStrongCrypto',
+      type: :dword,
+      data: new_resource.use_strong_crypto ? 1 : 0,
+    }]
+  end
+
+  registry_key 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\.NETFramework\\v4.0.30319' do
+    values [{
+      name: 'SchUseStrongCrypto',
+      type: :dword,
+      data: new_resource.use_strong_crypto ? 1 : 0,
+    }]
+  end
+end

--- a/test/cookbooks/test/recipes/share copy.rb
+++ b/test/cookbooks/test/recipes/share copy.rb
@@ -1,0 +1,2 @@
+windows_schannel 'tls 1.2' do
+end

--- a/test/integration/schannel/share_spec.rb
+++ b/test/integration/schannel/share_spec.rb
@@ -1,0 +1,3 @@
+describe powershell('[Net.ServicePointManager]::SecurityProtocol') do
+  its('strip') { should match /Tls12/ }
+end


### PR DESCRIPTION
Signed-off-by: Jason Field <jason@avon-lea.co.uk>

### Description
Adds the ability to configure windows schannel, which is used by dotnet applications including powershell to speak to tls 1.2 endpoints

### Issues Resolved

#584 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
